### PR TITLE
Story quality overhaul + /benchmark model-shootout visualization

### DIFF
--- a/docs/reviews/2026-07-17-story-output-review.md
+++ b/docs/reviews/2026-07-17-story-output-review.md
@@ -1,0 +1,419 @@
+# Story output quality review — current baseline
+
+**Date:** 2026-07-17  
+**Model/config:** current application defaults (`deepseek/deepseek-v4-flash` through OpenRouter; no `CACTUS_*` overrides)  
+**Method:** Six questions were posted concurrently to `POST /api/generate`; every NDJSON stream was read to completion and its `publicationToken` was posted to `POST /api/generate/publish`. All six generation and publication requests returned HTTP 200. The emitted plans, scene bodies, stream events, publication tokens, and publish responses are preserved verbatim in `local://before-stories.json`.
+
+This is a review of one nondeterministic sample, not a model benchmark. It does, however, show recurring defects across unrelated questions.
+
+## Summary
+
+- The final emitted plans were structurally healthy in this sample: **6/6 published**, no empty `projectSlugs` arrays, and no repeated Scene Pattern within a story. That is better than the reported historical first-attempt validity, but the stream does not expose failed internal attempts.
+- Content quality is much weaker than structural validity. Of 20 claims, **12 contain a named employer, project, technology, or domain fact; 7 are generic/inferred synthesis; 1 is an honest boundary statement**. Several of the 12 anchored claims still add unsupported conclusions.
+- The dominant shape is a presentation template: `hero-statement` → one or two evidence scenes → `closing-synthesis`. All six use the same opening and closing patterns; none use `timeline` or `system-diagram`.
+- Scene bodies often paraphrase claims instead of adding evidence. The 3D-printing story repeats essentially one corpus sentence across all three scenes.
+- Asset selection is often metaphorical decoration rather than semantic illustration. Only the two 3D-printing scenes using `print-layers` and `printer-forge`, and the AI-tooling opener using `circuit-mind`, are unambiguously strong matches.
+- More importantly, the real UI is **pattern-driven and does not render the selected `assetId` during normal Remotion playback**. The catalog Motion Asset is only the reduced-motion/runtime/Suspense fallback. Improving asset selection alone will not change what most visitors see.
+- The car answer does not invent a vehicle, which is good, but it treats public contact links as evidence of absence and pads the refusal into unrelated portfolio promotion.
+
+## Plan quality
+
+### Structure and repetition
+
+| Question | Emitted scene plan (`title` — pattern / register / asset) |
+|---|---|
+| What car does Noah drive? | “No car on record” — `hero-statement` / editorial / `morning-coffee`; “What I actually build” — `evidence-ledger` / technical / `print-layers`; “The bigger picture” — `closing-synthesis` / reflective / `morning-coffee` |
+| What does Noah do at MerchantSpring? | “Current Role” — `hero-statement` / editorial / `circuit-mind`; “Full-Stack Scope” — `evidence-ledger` / technical / `print-layers`; “Impact” — `closing-synthesis` / reflective / `printer-forge` |
+| How does Noah balance engineering and design? | “One integrated craft” — `hero-statement` / editorial / `circuit-mind`; “Projects that prove the blend” — `project-spotlight` / technical / `print-layers`; “Spanning the spectrum” — `capability-map` / diagrammatic / `container-stack`; “Iteration as the balance” — `closing-synthesis` / reflective / `morning-coffee` |
+| What is Noah’s experience with 3D printing? | “Hands-On 3D Printing” — `hero-statement` / editorial / `circuit-mind`; “From CAD to Finished Part” — `evidence-ledger` / technical / `print-layers`; “Making Things That Matter” — `closing-synthesis` / reflective / `printer-forge` |
+| Which projects best show Noah’s technical range? | “Full-Stack Range” — `hero-statement` / editorial / `circuit-mind`; “Image & Language Tools” — `project-spotlight` / technical / `printer-forge`; “Generative Portfolio & Color” — `capability-map` / diagrammatic / `container-stack`; “Synthesis of Skills” — `closing-synthesis` / reflective / `morning-coffee` |
+| What tools does Noah use for AI and LLM development? | “AI & LLM Toolchain” — `hero-statement` / technical / `circuit-mind`; “Evaluation in Practice” — `evidence-ledger` / diagrammatic / `data-center`; “Why This Stack Matters” — `closing-synthesis` / editorial / `morning-coffee` |
+
+Across 20 scenes, the pattern distribution is `hero-statement` 6, `closing-synthesis` 6, `evidence-ledger` 4, `project-spotlight` 2, and `capability-map` 2. The titles “Current Role,” “Impact,” “The bigger picture,” “Spanning the spectrum,” “Making Things That Matter,” “Synthesis of Skills,” and “Why This Stack Matters” are interchangeable slide headings rather than story-specific editorial choices.
+
+### Claim specificity
+
+- **Car:** the opening is appropriately a boundary claim: “I don't have any information about the car I drive.” Scene 2 is concrete (“marketplace analytics, data-labeling tooling, and LLM evaluation tools”), but is unrelated to the question. Scene 3 is pure slideware: “my portfolio shows the kind of work I do.”
+- **MerchantSpring:** the first two claims are checkable: “Senior AI Engineer at MerchantSpring,” “marketplace analytics for e-commerce sellers and agencies,” and “backend services, data pipelines, and frontend development.” The closing claim—“cohesive, reliable analytics tools that directly help sellers and agencies make better decisions”—adds outcomes that are not in the cited career excerpt.
+- **Engineering and design:** “two sides of the same craft” is a philosophy invented from a generic bio, not a checkable fact. Ask-Me Portfolio, Moodify, the named tool stack, and FDM are concrete. “layer by layer, I refine both the look and the logic” is an attractive metaphor, not evidence.
+- **3D printing:** role, employer, year, FDM, CAD, and high-end materials are checkable. “functional parts” is not stated in either cited excerpt. “a core part of my maker identity” is generic interpretation.
+- **Technical range:** the four named projects and their basic functions are concrete. “showing the full stack of my technical range” and “my ability to work across AI, infrastructure, and user experience” are broad conclusions; the cited project excerpts do not themselves establish infrastructure work.
+- **AI/LLM tools:** the tool list and Supa/LLM Comparison app are checkable. “using these frameworks” is not established by the cited app evidence, and “bridging prototyping with production” is generic positioning.
+
+The planner can select evidence IDs correctly while still making a conclusion that the excerpt does not entail. Evidence attachment is therefore not the same as grounding.
+
+## Scene body quality
+
+### Verbatim examples and redundancy by story
+
+#### 1. What car does Noah drive?
+
+- Claim: “I don't have any information about the car I drive.”
+- Body: “My public contact links show no details about any car I might drive.”
+- Closing claim: “While I can't answer that specific question, my portfolio shows the kind of work I do.”
+- Closing body: “I can't answer that specific question, but my portfolio—the site you're on right now, built with an LLM composing answers from a component catalog, and Moodify, which pulls album‑cover palettes into the page—shows exactly the kind of work I do.”
+
+The first body merely restates the absence claim and uses unrelated contact links as proof. The next two scenes abandon the car question and turn the refusal into a portfolio advert. “The bigger picture” and “shows exactly the kind of work I do” are filler around otherwise concrete project facts.
+
+#### 2. What does Noah do at MerchantSpring?
+
+- Opening claim: “I am a Senior AI Engineer at MerchantSpring, focused on building marketplace analytics for e-commerce sellers and agencies.”
+- Opening body: “I currently build marketplace analytics for e-commerce sellers and agencies as a Senior AI Engineer at MerchantSpring, working full-stack across backend services, data pipelines, and frontend.”
+- Evidence claim: “My work spans backend services, data pipelines, and frontend development, supported by infrastructure and DevOps skills.”
+- Evidence body: “At MerchantSpring, my work covers the full stack—backend services, data pipelines, and frontend—backed by infrastructure and DevOps skills like Docker, Proxmox, and Terraform.”
+- Closing body: “By working across every layer—backend services, data pipelines, and frontend—I ensure the analytics tools I ship are cohesive and reliable, directly helping sellers and agencies make better decisions.”
+
+This has a coherent role → scope → outcome order, but each scene repeats “backend services, data pipelines, and frontend.” The closing turns that repeated inventory into unsupported impact language: “cohesive and reliable” and “make better decisions.”
+
+#### 3. How does Noah balance engineering and design?
+
+- Opening claim: “I see engineering and design as two sides of the same craft, not separate disciplines.”
+- Project body: “Ask-Me Portfolio pairs an LLM-backed backend that generates JSON specs with a frontend that renders them over a WebGL shader backdrop. Moodify blends a search-driven backend that extracts album color palettes with a frontend that dynamically recolors the page—each project marrying design and engineering.”
+- Capability body: “I work across Ruby, Python, JavaScript, TypeScript, and Node.js, pair Next.js, Rails, and Tailwind CSS for frontend work, and manage Docker, Proxmox, Unraid, AWS, and Terraform for infrastructure. On the side, I dive into 3D printing with FDM and high-end materials.”
+- Closing body: “I refine both the look and the logic through iteration—whether I'm polishing a UI component or adjusting a 3D print, each layer brings me closer to balance.”
+
+The project scene is the strongest scene in this story because it names observable mechanisms. The capability scene becomes a résumé list rather than evidence of *how* balance is achieved. The ending repeats the invented “iteration” thesis and adds “polishing a UI component,” which is not in the cited excerpts. Flow exists, but the evidence does not actually prove the opening philosophy.
+
+#### 4. What is Noah’s experience with 3D printing?
+
+- Scene 1 body: “Since 2023, I've worked as a CAD designer and 3D printing engineer at Bowiq, operating FDM machines with high-end materials.”
+- Scene 2 body: “Since 2023, I've been designing functional parts in CAD and printing them on FDM machines with premium materials at Bowiq.”
+- Scene 3 body: “Since 2023, I have been designing and fabricating with FDM 3D printing and high-end materials at Bowiq, which is how I combine CAD, engineering, and hands-on making.”
+
+All three bodies repeat the same year, employer, CAD/FDM, and materials fact. Scene 2 introduces “functional parts,” which is absent from the evidence. Scene 3 wraps the same sentence in “maker identity” and “Making Things That Matter.” This is the clearest placeholder-PPT failure: a single fact is stretched into three slides rather than developed.
+
+#### 5. Which projects best show Noah’s technical range?
+
+- Opening body: “From a computer vision cutout tool using Segment Anything, to an LLM comparison app, to the generative UI of this very portfolio, and a color extraction app that recolorizes the hero — these projects demonstrate my full-stack technical range.”
+- Project body: “I built a fun little app that uses Segment Anything to cut people and objects out of images for stickers, and an open-source LLM Comparison app where users can pit two models side by side.”
+- Portfolio/Moodify body: “The portfolio you're exploring uses an LLM to compose each answer as a JSON spec, rendered from a component catalog. Meanwhile, Moodify extracts album-cover color palettes, and that same trick now recolors this site's hero dither.”
+- Closing body: “The AI image cutout, LLM comparison, this portfolio, and Moodify highlight my ability to work across AI, infrastructure, and user experience.”
+
+Scenes 2 and 3 contain concrete mechanisms. Scenes 1 and 4 are redundant summaries of the same four-project list. The closing adds “infrastructure” without explaining which project demonstrates it. “Full-Stack Range” and “Synthesis of Skills” read as deck section labels, not a narrative.
+
+#### 6. What tools does Noah use for AI and LLM development?
+
+- Opening body: “I build AI and LLM workflows using LangChain for orchestration, Langfuse for observability, Ollama for local inference, Hugging Face for model access, and OpenRouter for multi-provider API routing.”
+- Evidence body: “At Supa, I built LLM evaluation tooling and shipped the open-source LLM Comparison app, which lets users pit two models against each other.”
+- Closing claim: “My AI toolset emphasizes open-source frameworks and hands-on evaluation, bridging prototyping with production.”
+- Closing body: “I rely on open-source tools like LangChain and Ollama, and building the LLM Comparison app let me validate ideas in prototype before pushing them into production.”
+
+The corpus provides a list of tool names, but not the per-tool uses assigned in scene 1. Those descriptions are plausible industry knowledge, not portfolio evidence. Likewise, the cited material does not say the comparison app moved prototypes into production. The story has a sensible list → example → synthesis shape, but its most polished phrases—“bridging prototyping with production” and “validate ideas in prototype before pushing them into production”—are the least grounded.
+
+### Cross-story body findings
+
+1. **Bodies frequently repeat the claim.** In the UI, claim and body are adjacent, so paraphrase is especially visible. MerchantSpring scene 3 and technical-range scene 4 are near duplicates; all three 3D-printing scenes repeat one fact.
+2. **Synthesis is where grounding weakens.** The model converts named facts into uncheckable value statements: “make better decisions,” “core part of my maker identity,” “ability to work across,” and “bridging prototyping with production.”
+3. **World knowledge leaks into evidence prose.** Tool functions, “functional parts,” Moodify’s “search-driven backend,” and prototype-to-production impact are not contained in the cited excerpts.
+4. **Narrative flow is usually classification, not progression.** Most stories say answer → list → generic conclusion. The technical-range pair grouping is useful; the 3D story has no progression at all.
+
+## Animation and asset semantics
+
+### Catalog baseline
+
+The catalog contains eight records, but `spark-loader` is `generatorEligible: false` and therefore is not offered to the planner.
+
+| Asset | Catalog meaning and tags |
+|---|---|
+| `printer-forge` | A working 3D printer turns digital intent into a physical object; `3d-printing`, `fabrication`, `making`, `delivery` |
+| `print-layers` | A 3D form emerges from precise stacked layers; `3d-printing`, `layers`, `evidence`, `iteration` |
+| `circuit-mind` | A robot brain/circuit model of technical reasoning; `ai`, `systems`, `reasoning`, `architecture` |
+| `spark-loader` | Ambient decorative loading sparkle; `loading`, `sparkles`, `ambient`, `decorative`; not generator-eligible |
+| `data-center` | Dependable product infrastructure represented by server racks; `infrastructure`, `servers`, `operations`, `evidence` |
+| `server-sweep` | Ordered server maintenance/cleanup; `servers`, `maintenance`, `operations`, `timeline` |
+| `container-stack` | Deployable infrastructure/composable services; `containers`, `docker`, `infrastructure`, `deployment` |
+| `morning-coffee` | A human technical-craft ritual; `coffee`, `ritual`, `craft`, `synthesis` |
+
+### Per-scene semantic fit
+
+| Story / scene | Selected asset | Assessment against catalog semantics |
+|---|---|---|
+| Car 1, “No car on record” | `morning-coffee` | **Mismatch.** Coffee/human rhythm has no semantic relation to unavailable car data. |
+| Car 2, “What I actually build” | `print-layers` | **Mismatch.** Marketplace analytics, labeling, and LLM evaluation are not 3D layers or fabrication. `evidence` is too broad a tag to make this meaningful. |
+| Car 3, “The bigger picture” | `morning-coffee` | **Weak.** `synthesis` pattern eligibility is satisfied, but the coffee ritual adds no meaning to the portfolio detour. |
+| MerchantSpring 1, “Current Role” | `circuit-mind` | **Partial.** The role is AI engineering, so `ai` fits; the claim itself is marketplace analytics rather than reasoning/architecture. |
+| MerchantSpring 2, “Full-Stack Scope” | `print-layers` | **Weak metaphor.** “Layers” loosely echoes full-stack, but the catalog visual specifically depicts 3D printing. |
+| MerchantSpring 3, “Impact” | `printer-forge` | **Mismatch.** “Ship”/`delivery` is being used as a generic software metaphor for a literal 3D-printer asset. |
+| Engineering/design 1, “One integrated craft” | `circuit-mind` | **Partial.** Systems/reasoning covers engineering, not the claimed design-engineering integration. |
+| Engineering/design 2, project spotlight | `print-layers` | **Weak.** It illustrates neither the LLM component catalog nor album-color extraction; “iteration” is not in the scene. |
+| Engineering/design 3, capability map | `container-stack` | **Partial/strong for one slice.** Docker/infrastructure is explicitly named, but frontend design and 3D printing are equally central to the claim. |
+| Engineering/design 4, synthesis | `morning-coffee` | **Weak.** `craft`/`synthesis` loosely fits, but the scene is about iteration and 3D layers, not coffee or ritual. |
+| 3D printing 1, direct answer | `circuit-mind` | **Mismatch.** A 3D-printer asset would be direct; the selected AI brain is unrelated. |
+| 3D printing 2, evidence | `print-layers` | **Strong.** FDM construction and layered fabrication match exactly. |
+| 3D printing 3, synthesis | `printer-forge` | **Strong.** CAD-to-physical fabrication is exactly the catalog meaning. |
+| Technical range 1, direct answer | `circuit-mind` | **Partial.** AI is one of four domains, but the visual overweights it. |
+| Technical range 2, image/LLM projects | `printer-forge` | **Mismatch.** Neither Segment Anything nor model comparison is 3D fabrication. |
+| Technical range 3, portfolio/Moodify | `container-stack` | **Mismatch.** The claim is generative UI and color extraction, not Docker, containers, or deployment. |
+| Technical range 4, synthesis | `morning-coffee` | **Weak.** A generic “craft” sign-off is decoration, not a visualization of AI/infrastructure/UX range. |
+| AI tools 1, toolchain | `circuit-mind` | **Strong.** AI systems and reasoning fit the toolchain. |
+| AI tools 2, evaluation | `data-center` | **Partial.** It conveys operational infrastructure, but the evidence is model comparison/evaluation, not servers or operations. |
+| AI tools 3, synthesis | `morning-coffee` | **Mismatch.** Open-source evaluation and prototype-to-production claims have no coffee/ritual content. |
+
+Asset frequency reinforces the template effect: `circuit-mind` 5, `morning-coffee` 5, `print-layers` 4, `printer-forge` 3, `container-stack` 2, `data-center` 1, and `server-sweep` 0. The model repeatedly uses `morning-coffee` as a generic closing icon and interprets 3D “layers”/“delivery” as generic software metaphors.
+
+### What visitors actually see
+
+I inspected and scrolled two published stories in Chromium at 1440×1000:
+
+- `/ask/rmPU3hiTuosBxidpT-2yg0wN` — technical range, all four scenes
+- `/ask/_Hu7CQLh-wLyvSM_tD6JV-6L` — car boundary answer, all three scenes
+
+Representative captures were taken at:
+
+- `/tmp/story-review-technical-range-scene-2.png`
+- `/tmp/story-review-car-scene-1.png`
+- `/tmp/story-review-car-scene-3.png`
+
+The visitor first sees the question as a large page heading, a sticky left “SCENES” rail, and a large 16:9 animation stage. The role/index chip sits at the stage’s top-left. Below the stage, the claim is prominent, the body is lower-contrast prose directly underneath, and project links follow. Evidence is behind a small “Sources for this claim” button.
+
+Pattern compositions also render story text inside the animation:
+
+- In the car hero, “No car on record” and “I don't have any information about the car I drive” appear large inside the stage. The canonical claim appears again below the stage, followed by the body. At the initial viewport, that body is below the fold, so the visitor initially sees only the refusal claim.
+- In the technical-range project spotlight, the stage carries “Image & Language Tools” and animated project-card presentation; the claim and body sit immediately below. The broad phrase “AI Image Cutout uses segment anything …” is therefore followed at once by a body that says nearly the same thing.
+- In the car closing synthesis, the animation displays the three scene titles as floating cards. Directly beneath it, the generic claim “my portfolio shows the kind of work I do” is the highest-contrast text, followed by a longer paraphrase. The visual polish makes the filler more conspicuous, not less.
+
+**Critical implementation fact:** normal presentation is selected by `SCENE_COMPOSITIONS[scene.pattern]`. The Remotion composition subtree does not read `scene.assetId`. `MotionAsset assetId={scene.assetId}` is supplied only as the reduced-motion, Suspense, or runtime-error fallback. Therefore, the selected `morning-coffee`, `printer-forge`, and other catalog assets assessed above are plan metadata under normal playback, not the animation visitors see. Prompt-side asset improvements cannot improve normal UI semantics until that integration gap is resolved.
+
+## Boundary behavior
+
+The car story correctly refuses to name a vehicle. There is no fabrication such as a make or model. That is the strongest part of the output.
+
+It still stretches in three ways:
+
+1. “My public contact links show no details about any car I might drive” treats a contact-link list as evidence that no answer exists. Absence from that unrelated excerpt is not evidence.
+2. “What I actually build” inserts marketplace analytics, data labeling, and LLM evaluation into a car answer. Those facts are true but irrelevant.
+3. “The bigger picture” then promotes Ask-Me Portfolio and Moodify. The answer becomes a generic three-scene portfolio funnel instead of an honest boundary response.
+
+A grounded boundary answer would be:
+
+> I don't have a reliable source in Noah's portfolio for what car he drives, so I can't answer without guessing. I can answer questions about his work at MerchantSpring, his projects, AI tooling, or 3D printing.
+
+Within the required direct-answer/evidence/synthesis arc, the evidence scene should describe the *available corpus coverage* without attaching an unrelated citation as proof of absence, and the synthesis should offer answerable alternatives rather than pretend unrelated projects answer the question.
+
+## Related questions
+
+### Verbatim output and quality
+
+- **Car:** “What projects have you built?”, “What is your professional background?”, “Where are you located?” All are generic escape hatches. The first follows the story’s detour; none helps clarify the unanswered car question. They are at least likely answerable by the corpus.
+- **MerchantSpring:** “What did you build during your time at Supa?”, “What programming languages and tools do you use most often?”, “Can you tell me about your Ask-Me Portfolio project?” All are answerable, but only the Supa comparison is a natural continuation. The other two discard the MerchantSpring topic instead of asking about analytics, data pipelines, or the current role.
+- **Engineering/design:** “What is the Ask-Me Portfolio and how does it work?”, “How does Noah's 3D printing background shape his engineering approach?” The first is grounded and relevant. The second asks for a causal influence not present in the corpus and is likely to produce another invented philosophy.
+- **3D printing:** “What is your role at Bowiq?”, “What do you enjoy most about 3D printing?”, “What other maker skills do you have?” Bowiq is grounded. Enjoyment and other maker skills are not supported by the supplied 3D evidence.
+- **Technical range:** “How does the Ask Me Portfolio generate its answers?”, “What infrastructure does Noah use for self-hosting?”, “Can you tell me more about the Moodify project?” These are the best set: specific, varied, and plausibly supported elsewhere in the corpus, although the self-hosting question should only be offered if the retrieved corpus contains that detail.
+- **AI/LLM tools:** “Does Noah self-host any of these AI/LLM tools on his homelab?”, “What other programming languages does Noah use for backend development?”, “How does Noah’s portfolio site itself leverage AI or LLM techniques?” The latter two are grounded. The first combines two corpus themes into a specific claim (“these tools” on a homelab) that the current evidence does not establish.
+
+The recurring defect is that related questions are generated for conversational appeal rather than checked answerability. Several are invitations to fabricate the next story.
+
+## Prioritized recommendations
+
+1. **P0 — Make entailment explicit for both claims and bodies.** Every factual sentence must be directly supported by one or more cited excerpts. A list of tool names does not authorize invented usage details; a job description does not authorize invented outcomes. Require the planner/composer to identify the exact supporting phrase before writing.
+2. **P0 — Add an honest-boundary mode without changing the three-role validator contract.** If no evidence answers the question: direct answer = explicit uncertainty; evidence = what the corpus actually covers, without using unrelated records as negative proof; synthesis = grounded alternatives. Prohibit padding with unrelated portfolio achievements as if they answer the question.
+3. **P0 — Require bodies to add information.** A body must introduce at least one new grounded detail, contrast, chronology, mechanism, or example not already present in the claim. If evidence cannot support expansion, keep the sentence direct rather than paraphrasing it. Explicitly reject claim/body pairs with the same nouns and conclusion reordered.
+4. **P1 — Ban placeholder slide language.** Add negative examples for “The bigger picture,” “Impact,” “Synthesis of Skills,” “Why This Stack Matters,” “shows the kind of work I do,” “ability to work across,” “core part of my identity,” and “bridging prototyping with production.” Titles should name the actual fact or tension in the scene.
+5. **P1 — Make synthesis evidence-preserving.** The final scene should connect named facts already established, not upgrade them into generic impact. For example, the MerchantSpring synthesis can connect backend, pipelines, and frontend as an end-to-end scope; it cannot claim reliability or better decisions unless the corpus says so.
+6. **P1 — Enforce semantic asset choice rather than pattern eligibility alone.** Require overlap between the scene’s concrete subject and catalog description/tags. Forbid `printer-forge`/`print-layers` as generic metaphors for software delivery or stack layers, and forbid `morning-coffee` as a default closing asset. Also acknowledge that the current catalog has no honest semantic match for an unavailable-car boundary scene.
+7. **P1 — Wire selected assets into normal scene presentation, or remove the misleading selection requirement.** This is outside prompt-only work but blocks the intended visitor benefit: today `assetId` only controls fallback rendering, while normal visitors see pattern compositions. Prompt tuning cannot fix that implementation gap.
+8. **P2 — Give each scene a distinct narrative job.** Direct answer should answer; evidence scenes should each prove a different part using distinct facts; synthesis should state the specific connection. Do not spend both opening and closing scenes summarizing the same project list.
+9. **P2 — Generate only corpus-answerable related questions.** Before emitting each question, require at least one known evidence ID that could answer it. Reject causal, preference, and deployment questions unless the corpus explicitly contains that information.
+10. **P2 — Increase plan variety only when evidence warrants it.** Use `timeline` for dated progression and `system-diagram` for an actual architecture. Do not force every story into hero/evidence/closing slide rhythm when a more concrete pattern is supported.
+
+The highest-leverage prompt change is not more stylistic instruction. It is a hard distinction between **entailed fact**, **clearly labeled inference**, and **unknown**, combined with a non-redundancy rule for adjacent claim/body text.
+
+## After: 2026-07-17 prompt + composition changes
+
+### Sample and method
+
+The same six questions were generated against the revised prompts with the application defaults (`deepseek/deepseek-v4-flash` through OpenRouter; no `CACTUS_*` overrides), then published. The dev server used `STORY_CACHE_HMAC_KEY=devsecret` and `STORY_CACHE_HMAC_KEY_ID=dev`. All six generation requests were cache misses, all six generation requests returned HTTP 200, and all six publication requests returned HTTP 200.
+
+The complete AFTER records—including response headers, raw NDJSON streams, parsed events, final plans, scene bodies, publication tokens, publish responses, and event timings where captured—are preserved verbatim in `local://after-stories.json`.
+
+| Question | Published Story | Plan emitted | Generation complete | Generate / publish |
+|---|---|---:|---:|---|
+| What car does Noah drive? | `yzCnuDAAIVyWw1Vl1Inc06uo` | not separately timed | 83.495 s | 200 / 200 |
+| What does Noah do at MerchantSpring? | `f17eif6P7vsHIfhA_WI7f6sh` | 39.890 s | 68.847 s | 200 / 200 |
+| How does Noah balance engineering and design? | `SPEA1n8ScCfj2IecnhwZD9EU` | 49.172 s | 80.281 s | 200 / 200 |
+| What is Noah's experience with 3D printing? | `pwdfxBeLTUlO3wo_abE8Kr_u` | 54.099 s | 103.557 s | 200 / 200 |
+| Which projects best show Noah's technical range? | `_wg2fplsCCLLyibQyRyPzXEL` | 44.444 s | 121.428 s | 200 / 200 |
+| What tools does Noah use for AI and LLM development? | `1uoZjs2kpWI8YZZ0-BxlvDfN` | 24.015 s | 117.558 s | 200 / 200 |
+
+No generation error, validation error, or explicit repair event appeared in any stream or in the server log. Each stream exposed one plan followed by three scenes. The long gaps before some final scenes—27.911 seconds for technical range and 53.704 seconds for AI tooling—could be ordinary provider latency or an internal repair, but the observable data cannot distinguish those cases; they are not counted as repair rounds.
+
+### AFTER plans
+
+| Question | Emitted scene plan (`title` — pattern / asset) |
+|---|---|
+| Car | “No Car Information Available” — `hero-statement` / `circuit-mind`; “Corpus Coverage: Career, Skills, and Projects” — `evidence-ledger` / `print-layers`; “Redirecting to Answerable Questions” — `closing-synthesis` / `morning-coffee` |
+| MerchantSpring | “Senior AI Engineer at MerchantSpring” — `hero-statement` / `circuit-mind`; “Full-Stack Developer in Practice” — `evidence-ledger` / `data-center`; “Analytics for E-Commerce Sellers and Agencies” — `closing-synthesis` / `morning-coffee` |
+| Engineering and design | “Full-stack developer with a design eye” — `hero-statement` / `circuit-mind`; “Frontend frameworks and a visual project” — `capability-map` / `data-center`; “End-to-end tooling and a portfolio driven by LLMs” — `closing-synthesis` / `morning-coffee` |
+| 3D printing | “CAD Designer and 3D Printing Engineer at Bowiq” — `hero-statement` / `circuit-mind`; “Professional and Personal 3D Printing Focus” — `evidence-ledger` / `print-layers`; “Dedication to FDM and High-End Materials” — `closing-synthesis` / `printer-forge` |
+| Technical range | “Ask-Me Portfolio and LLM Comparison App” — `hero-statement` / `circuit-mind`; “LLM Pipeline and Open-Source Comparison” — `capability-map` / `data-center`; “Full-Stack and AI Engineering Across Two Projects” — `closing-synthesis` / `morning-coffee` |
+| AI/LLM tools | “AI and LLM Development Tooling” — `hero-statement` / `circuit-mind`; “The LLM Comparison App” — `capability-map` / `circuit-mind`; “Connecting the tools to the app” — `closing-synthesis` / `morning-coffee` |
+
+The AFTER pattern distribution is `hero-statement` 6, `closing-synthesis` 6, `evidence-ledger` 3, and `capability-map` 3 across 18 scenes. As in the baseline, every story still uses a hero opener and closing-synthesis ending. Neither `timeline` nor `system-diagram` was selected, even though the Ask-Me Portfolio excerpt describes an explicit LLM → JSON spec → component-catalog rendering path.
+
+### Criterion verdicts
+
+| Criterion | Verdict | Factual before/after comparison |
+|---|---|---|
+| Title genericness | **Improved** | The 11 title strings explicitly banned by the new prompt occurred **7/20** times before (“The bigger picture,” “Current Role,” “Impact,” “Making Things That Matter,” “Full-Stack Range,” “Synthesis of Skills,” and “Why This Stack Matters”) and **0/18** times after. AFTER titles name facts more often, for example “Senior AI Engineer at MerchantSpring.” Some remain deck-like or procedural: “AI and LLM Development Tooling” and “Redirecting to Answerable Questions.” |
+| Claim specificity | **Improved** | The baseline had 12/20 claims with a named employer, project, technology, or domain fact, seven generic/inferred claims, and one boundary claim. AFTER has one boundary claim and **17/17 non-boundary claims containing at least one checkable named fact**. Examples include “Since 2023, I've been a CAD Designer and 3D Printing Engineer at Bowiq” and “I use LangChain, Langfuse, Ollama, Hugging Face, and OpenRouter.” Specificity does not guarantee entailment: the AI-tool synthesis still asserts an unsupported relationship. |
+| Body value-add versus claim paraphrase | **Improved, not fixed** | All 18 AFTER bodies satisfy the requested 2–4 sentence length. Most add at least one grounded detail: the MerchantSpring opener adds “backend services, data pipelines, and frontend development” to the role claim, and the Moodify body adds Tailwind CSS plus the hero-dither reuse. Five scenes still fail or substantially miss the value-add rule: the car opener uses irrelevant negative proof; 3D-printing scenes 2 and 3 restate their claims; technical-range scene 2 repeats its two mechanisms; and the AI-tool opener repeats the five-name list before adding only “That's the tooling I rely on.” |
+| Cross-scene fact repetition | **Regressed** | The baseline's one-fact-three-slides 3D story remains. AFTER scene bodies repeat “Bowiq,” “Since 2023,” “FDM,” and “high-end materials” in all three scenes; the last says, “My personal 3D printing interest is the same: FDM and high-end materials.” In addition, the technical-range story shrank from four distinct projects to two and repeats the Ask-Me Portfolio mechanism and LLM Comparison app in every scene. MerchantSpring also repeats marketplace analytics plus the backend/pipelines/frontend inventory three times. |
+| Car-question boundary honesty | **Improved, not fixed** | BEFORE used contact links as negative proof—“My public contact links show no details about any car I might drive”—then advertised unrelated work. AFTER starts more precisely: “The corpus does not contain any information about a car,” and ends with answerable redirects to Supa, LLM Comparison, and self-hosting. However, its first body still uses an unrelated excerpt as negative proof: “My profile headline identifies me as a Full-Stack Developer, but it contains no information about a car.” The middle scene is explicitly corpus coverage rather than pretending projects answer the car question, but it is still a long detour. |
+| Related-question answerability | **Improved** | The baseline offered unsupported preference/causal questions such as “What do you enjoy most about 3D printing?” and “How does Noah's 3D printing background shape his engineering approach?” Every AFTER suggestion has a plausible corpus route. Strong examples are “What open-source project did Noah ship for LLM evaluation?”, “What company does Noah work for as a 3D printing engineer?”, and “How does the Ask-Me Portfolio generate its pages?” Two remain synthesis-shaped rather than direct lookups—“How does Noah's portfolio site demonstrate his engineering and design skills?” and “Which projects has Noah built and open-sourced?”—but neither requires a new preference or causal fact. |
+| Asset and pattern semantic fit | **Same overall; mixed movement** | Software scenes no longer use `printer-forge` as a shipping metaphor, and `data-center` is a better fit for MerchantSpring backend/data-pipeline scope than the old `print-layers`. But `morning-coffee` remains at **5 uses before and 5 after**, again serving as the default closer; the car corpus-coverage scene still uses literal 3D `print-layers`; Moodify/frontend work uses a server-rack `data-center`; and the 3D opener still uses the AI-brain `circuit-mind`. Pattern variety also did not improve: the same hero/closing frame appears in all six stories, with zero timelines and zero system diagrams. |
+| Invented facts / entailment | **Improved, not fixed** | BEFORE invented per-tool uses (“LangChain for orchestration,” “Langfuse for observability,” “Ollama for local inference”), outcomes (“make better decisions”), “functional parts,” and a prototype-to-production story. AFTER correctly presents the five AI tools as a list and removes the MerchantSpring outcome claim and “functional parts.” Strict entailment violations remain and are listed below. |
+
+### Specificity and body findings by story
+
+- **Car:** the opening is an honest boundary rather than a guessed make/model. The two remaining claims contain concrete corpus-coverage facts, but the body still cites the unrelated profile headline to establish absence.
+- **MerchantSpring:** all three claims are specific and source-supported. The new titles are better; the story itself is nearly three rewrites of the same two career highlights.
+- **Engineering/design:** each claim now names evidence—MerchantSpring scope, Next.js/Rails/Moodify, then Supa/Ask-Me Portfolio—instead of leading with the invented “two sides of the same craft” philosophy. This is more factual, but it answers by inventory rather than explaining a documented balancing practice.
+- **3D printing:** employer, role, timeframe, FDM, machines, materials, and personal interest are checkable. There is still not enough source material for three distinct scenes, and the composer pads the same fact instead of shortening the story.
+- **Technical range:** the selected projects are concrete, but using only Ask-Me Portfolio and LLM Comparison narrows the demonstrated range compared with the baseline's AI Image Cutout + LLM Comparison + Ask-Me Portfolio + Moodify grouping. The two-project mechanism is repeated three times.
+- **AI/LLM tools:** the opening list is now honest about what the source establishes. The synthesis reintroduces the exact relationship the evidence does not establish: that those named tools powered the LLM Comparison app or Supa's data-labeling tooling.
+
+### Remaining entailment violations
+
+The following AFTER clauses are not stated by the cited `content/about-me/*` excerpts:
+
+1. **Engineering/design:** “I bring ideas to life through code, working from data-heavy services to polished interfaces.” `bio.md` says “bring ideas to life through code” and mentions a “keen eye for design,” but never says the interfaces are polished.
+2. **3D printing:** “Both my professional and personal projects rely on the same technology and material choices.” `fun-facts.md` says only “Into 3D printing / CAD (FDM, high-end materials)”; it does not establish personal projects or reliance on identical choices.
+3. **Technical range:** “the infrastructure behind end-to-end data tooling.” `career.md` says the Supa tooling was built end to end, not that infrastructure was part of the cited work. The related phrase “LLM orchestration” is also stronger than `ask-me-portfolio.md`'s narrower statement that an LLM composes a JSON spec.
+4. **AI/LLM tools:** “The AI and LLM tooling I use powers projects like the LLM Comparison app, which I built end-to-end.” The source lists tools separately, says the app was shipped, and attaches “end to end” to data-labeling and AI training-data tooling—not to the comparison app.
+5. **AI/LLM tools:** “I also use these tools to build data-labeling and AI training-data tooling end to end.” No excerpt connects LangChain, Langfuse, Ollama, Hugging Face, or OpenRouter to that Supa work.
+6. **LLM Comparison body:** “allowing users to see how different models compare in a side-by-side format.” The project source says users can pit two LLMs against each other and compare them; it does not state a side-by-side UI.
+
+### Browser and composition verification
+
+I opened the published car and MerchantSpring stories in Chromium at 1440×1000. Representative captures:
+
+- `/tmp/story-after-car-boundary.png`
+- `/tmp/story-after-car-evidence-ledger.png`
+- `/tmp/story-after-merchantspring-evidence-ledger.png`
+
+The car boundary capture visibly renders “No Car Information Available” and “The corpus does not contain any information about a car” inside the hero composition, with the same claim and the two-sentence boundary body below it.
+
+The new evidence-label rendering is real rather than plan-only metadata:
+
+- Car evidence ledger: “SENIOR AI ENGINEER AT MERCHANTSPRING,” “FULL-STACK DEVELOPER AT SUPA (FORMERLY SUPAHANDS),” “PROGRAMMING LANGUAGES SKILLS,” “AI & LLM TOOLING SKILLS,” and “LLM COMPARISON APP,” ending at “05 OF 05 MATCHED.”
+- MerchantSpring evidence ledger: “PROFILE HEADLINE” and “SENIOR AI ENGINEER AT MERCHANTSPRING,” both marked “MATCHED,” ending at “02 OF 02 MATCHED.”
+
+Remaining visual weaknesses are visible in the captures: the “02 EVIDENCE” pill overlaps the “EVIDENCE LEDGER” heading, long scene titles in the left rail truncate to ellipses, and the ledger leaves a large empty region while pushing the body lower on the page. No sampled plan selected `system-diagram` or `timeline`, so the SystemAssembly evidence labels and NightDrive factual Timeline chip were not exercised by this six-question AFTER corpus.
+
+### Remaining gaps
+
+- The prompt bans exact filler headings successfully, but it has not broken the universal hero → middle → closing deck template.
+- Distinct scene jobs are still the largest content failure: 3D printing, MerchantSpring, and technical range repeat facts instead of progressing.
+- Honest-boundary mode improves the refusal and redirect, but still permits an unrelated evidence excerpt to be used as negative proof.
+- Tool lists are no longer expanded into invented per-tool functions, but the composer still invents links between those tools and specific work.
+- Semantic asset choice remains weak for generic closers and for subjects without a catalog match.
+- The visible EvidenceLedger labels are useful, but layout overlap and rail truncation need visual cleanup; SystemAssembly and NightDrive still need a generated-story browser check.
+
+### Iteration 2
+
+The prompt-only follow-up was exercised against the same six questions with `STORY_CACHE_HMAC_KEY=devsecret`, `STORY_CACHE_HMAC_KEY_ID=dev`, the default model, and no `CACTUS_*` overrides. Each final generation was a cache miss, and all six successful generate/publish pairs returned HTTP 200. Three earlier streams (two car attempts and one engineering/design attempt) ended in typed plan-validation errors and were retried; they produced no story. `npx vitest run lib/llm/__tests__/prompt.test.ts` passes all seven tests. The project-role rule was added and test-covered after this final sample exposed the ownership gap; it was not behaviorally regenerated because the one allowed tightening/regeneration cycle had already completed.
+
+| Question | Published Story | Scenes | Generate / publish |
+|---|---|---:|---|
+| What car does Noah drive? | `eRpWk1yEyQtsl57SqL_Tpo63` | 3 | 200 / 200 |
+| What does Noah do at MerchantSpring? | `E3hrAhFG-_pGbQ9kELlgouHx` | 3 | 200 / 200 |
+| How does Noah balance engineering and design? | `cp9PedSQ0izGH0O4kYB024s8` | 3 | 200 / 200 |
+| What is Noah's experience with 3D printing? | `c0TQZzxJe03FInXU-aTIAyzf` | 3 | 200 / 200 |
+| Which projects best show Noah's technical range? | `Rt4NKpHb8-39ukU0n4WiZM_i` | 3 | 200 / 200 |
+| What tools does Noah use for AI and LLM development? | `Fvv5H6jDISV8KoPx39Zl8UpO` | 3 | 200 / 200 |
+
+**Required verdicts**
+
+- **Car negative proof — fixed.** The boundary body is the standalone sentence, “I don't have any information about a car I drive.” It does not cite, quote, or contrast an unrelated excerpt to prove absence.
+- **3D-printing repetition — not fixed.** Bowiq, CAD, FDM, high-end materials, and machines remain body substance in all three scenes; personal interest is substance in scenes 2 and 3. The timeframe is now confined to scene 1, but the core composite fact still repeats. Representative bodies are “Since 2023 I've been a CAD Designer and 3D Printing Engineer at Bowiq, where my work covers CAD design and FDM 3D printing with high-end materials and machines,” “At Bowiq I do CAD design and FDM 3D printing with high-end materials and machines,” and “At Bowiq, I work with CAD design and FDM 3D printing using high-end materials and machines.”
+- **Technical-range breadth — failed.** The story names only two actual projects: LLM Comparison and AI Image Cutout. Bowiq is employment, not a third project, despite the title “Three projects spanning software and hardware.” The opener says, “I built the LLM Comparison app, work as a CAD designer and 3D printing engineer at Bowiq, and created the AI Image Cutout tool.” The corpus had four projects available, so the requested threshold of at least three was missed.
+
+Across the complete sample, substance-level repetition remains. The counting unit is one concrete or composite proposition repeated as body substance in two or more scenes; titles, claims, and brief transitional clauses do not count.
+
+| Story | Count | Repeated body fact sets |
+|---|---:|---|
+| Car | 2 | AI Image Cutout mechanism and LLM Comparison mechanism both repeat in scenes 2–3. |
+| MerchantSpring | 2 | Marketplace-analytics audience and backend/data-pipeline/frontend scope repeat in scenes 1 and 3. |
+| Engineering/design | 3 | The bio design fact repeats in scenes 1 and 3; Ask-Me Portfolio and Moodify mechanisms repeat in scenes 2 and 3. |
+| 3D printing | 2 | The composite Bowiq/CAD/FDM/high-end-materials/machines fact repeats in all three scenes; personal interest repeats in scenes 2–3. |
+| Technical range | 3 | LLM Comparison, Bowiq 3D work, and AI Image Cutout repeat in scenes 1 and 3; Bowiq is also the substance of scene 2. |
+| AI/LLM tools | 2 | The five-tool list repeats in scenes 1 and 3; LLM Comparison repeats in scenes 2 and 3. |
+
+The entailment audit treats a standalone boundary absence and synthesis that merely names cited facts as acceptable by design. Date-derived ordering is acceptable only when the scene cites both dated excerpts. Project ownership is acceptable only when a cited excerpt states Noah's role; a project description alone establishes what the project does, not that Noah built it. The AI story no longer says the five tools power the app: its adjacent list and project sentences do not assert a usage relationship.
+
+Unsupported clause occurrences remain:
+
+1. **Car, scene 2 claim:** “I built the AI Image Cutout tool using segment anything, and I also built the open-source LLM Comparison app.”
+2. **Car, scenes 2 and 3 bodies:** “I built the AI Image Cutout tool, a fun little app that uses segment anything to cut people and objects out of images to use as stickers.” This unsupported ownership sentence occurs twice.
+3. **Car, scene 2 body:** “I also built the open-source LLM Comparison app, which allows users to pit two LLMs against each other and see how they compare.”
+4. **Car, scene 3 claim:** “I've built an AI image cutout tool and an LLM comparison app.”
+5. **Car, scene 3 body:** “I also built the LLM Comparison app, an open-source project that lets users pit two LLMs against each other and see how they compare.”
+6. **MerchantSpring claim:** “Before MerchantSpring, I built data-labeling and AI training-data tooling at Supa and shipped the open-source LLM Comparison app.” Supa ownership is supported, but the scene does not cite the dated MerchantSpring excerpt, so “Before MerchantSpring” is not established by its cited Refs.
+7. **MerchantSpring body:** “The marketplace analytics I build at MerchantSpring serve e-commerce sellers and agencies.” The source says the analytics are built *for* those audiences; “serve” upgrades that to an outcome.
+8. **3D-printing claim:** “My 3D printing experience combines professional design engineering at Bowiq and a personal passion for the technology.” The excerpts separately establish Bowiq work and being “Into 3D printing / CAD”; they do not state a combined practice, and “passion” strengthens “Into.”
+9. **Technical-range claim:** “I built the LLM Comparison app, work as a CAD designer and 3D printing engineer at Bowiq, and created the AI Image Cutout tool.” Neither cited project description states Noah's contribution.
+10. **Technical-range body:** “I built the LLM Comparison app, an open-source project that lets you pit two LLMs against each other.” The scene does not cite the Supa career excerpt that states he shipped it.
+11. **Technical-range body:** “I also created the AI Image Cutout tool, which uses Segment Anything to cut people and objects out of images for stickers.” The project description states the mechanism but not Noah's role.
+12. **AI/LLM-tools claim:** “I use LangChain, Langfuse, Ollama, Hugging Face, and OpenRouter, and I built the LLM Comparison app.” Its scene does not cite the Supa career excerpt that establishes the app contribution.
+13. **AI/LLM-tools body:** “I also built the open-source LLM Comparison app, which lets users pit two LLMs against each other and see how they compare.” Its scene likewise cites only the project description for the app.
+
+All other factual claim/body clauses in the final six stories were directly supported by their cited excerpts or fell within the acceptable boundary, adjacency, and synthesis cases above. Overall, Iteration 2 fixes the boundary negative-proof slip and removes the named tools→project usage assertion, but it does not solve cross-scene fact partitioning, technical-range breadth, or project-role grounding. A durable corpus-side fix would add explicit role/contribution lines to `content/about-me/projects/*.md`; that requires a user decision and was not made here.
+
+### Iteration 3 — variable scene counts
+
+The Story contract now accepts one to five scenes and explicitly distinguishes `mode: "grounded"` from `mode: "boundary"`. A Grounded Story requires at least one Evidence Ref on every Scene, including `n=1`. A Boundary Story requires exactly one `direct-answer`/`intro` Scene with no Evidence Refs; redirects live only in Related Questions. Two-scene Stories require `direct-answer` → `synthesis`, `intro` → `resolve`, distinct Patterns, and at least two Registers. Existing three-to-five-scene role, cue, Pattern, Register, and middle-evidence rules remain valid. The compatibility boundary is `v6`.
+
+The behavioral sample used `STORY_CACHE_HMAC_KEY=devsecret`, `STORY_CACHE_HMAC_KEY_ID=dev`, the default OpenRouter model, and freshly restarted development servers. The car question was generated and published again after adding the explicit mode discriminant; it was a cache miss and emitted `mode: "boundary"` with an empty Scene Evidence list and empty Story Evidence vocabulary. The 3D-printing and technical-range rows are the final variable-count samples from the preceding prompt run.
+
+| Question | Published Story | Scenes | Result |
+|---|---|---:|---|
+| What car does Noah drive? | `6Ih9X4_CaPg8y2yS5lUhxxk2` | 1 | Expected Boundary Story; `mode: "boundary"`, with zero Scene and Story Evidence Refs. |
+| What is Noah's experience with 3D printing? | `83OMYkoQVH3VN0fBsY9tpHum` | 1 | Expected thin-evidence shape; one scene cites `career-3` and `fun-fact-1`, so no fact is repeated across scenes. |
+| Which projects best show Noah's technical range? | `hzTTdjlEPeLUNPxuAb-3s0m5` | 3 | Expected rich count and breadth; the bodies name Ask-Me Portfolio, LLM Comparison, Moodify, and AI Image Cutout. |
+
+**Verbatim published scene output**
+
+1. **What car does Noah drive?** — 1 scene
+   - **“Vehicle Not Shared”**
+   - “I have not shared what car I drive.”
+2. **What is Noah's experience with 3D printing?** — 1 scene
+   - **“3D Printing at Bowiq”**
+   - “Since 2023, I've been a CAD Designer & 3D Printing Engineer at Bowiq, focusing on FDM 3D printing with high-end materials and machines. I'm also personally into 3D printing and CAD.”
+3. **Which projects best show Noah's technical range?** — 3 scenes
+   - **“Ask-Me Portfolio, LLM Comparison, Moodify, AI Image Cutout”**
+   - “I created Ask-Me Portfolio, where an LLM composes answers as a JSON spec rendered from a component catalog over a WebGL backdrop. LLM Comparison is an open-source project that lets users pit two LLMs against each other. Moodify searches a favourite tune and uses its album cover's colour palette to recolour the page. AI Image Cutout uses segment anything to cut people and objects out of images to use as stickers.”
+   - **“LLM composition, comparison, and dynamic frontends”**
+   - “Ask-Me Portfolio is the site you're on right now: an LLM composes answers as a JSON spec rendered from a component catalog over a WebGL shader backdrop. LLM Comparison is an open-source project that pits two LLMs against each other. Moodify lets you search a favourite tune and watch its album cover's palette take over the page — the same palette trick now recolouring this site's hero dither.”
+   - **“Across AI, tooling, and creative visuals”**
+   - “My portfolio includes the Ask-Me site that uses an LLM to compose answers, an LLM Comparison app that pits two models against each other, an AI Image Cutout tool that uses segment anything to create stickers, and Moodify which recolours the page with an album cover's colour palette.”
+
+The variable-count fix resolves the structural padding in the boundary and 3D-printing cases. The technical-range Story meets the requested three-scene/three-project threshold, but it still repeats project facts across all three bodies. The prompt explicitly requires disjoint fact ownership and forbids this repetition; the model violated that instruction, while the public validator accepted the structurally valid shape because it does not perform semantic entailment or cross-scene proposition comparison.
+
+**UI sanity**
+
+- `JourneyMap` and `NightDrive` already guard every `scenes.length - 1` denominator with `Math.max(1, ...)`.
+- The published one-scene car Story rendered its question header, one-item Story rail, direct-answer scene, and related questions. No transition or closing-synthesis scene was rendered. `ClosingSynthesis` is unreachable for `n=1` because validation requires the only role/Pattern to be `direct-answer`/`hero-statement`.
+- A zero-Evidence boundary scene hides the per-claim Sources affordance and the footer no longer renders “Grounded in 0 evidence references.”
+- Browser verification renders correctly: rail + question prelude/header + single Scene. The one-item rail names “Vehicle Not Shared,” the direct-answer Scene renders its title and body, and Related Questions follow it. The verification screenshot remained a temporary `/tmp` artifact; no binary proof was added to the repository.
+
+Verification: `npx tsc --noEmit` completed cleanly; targeted Story, prompt, generate API, and StoryExperience tests passed; full `npx vitest run` passed 38 files and 285 tests.
+
+## Model shootout — 2026-07-18
+
+The pipeline evaluation ran five Story questions per model through planning, repair, scene composition, and the same validators used by the application. Repetition is the maximum and mean cross-scene body-token Jaccard score per Story; lower is better.
+
+| Model | Plan first-try valid | Plan final valid | Scenes valid | Repetition max | Repetition mean | Banned phrases | Mean story ms | Prompt tokens | Completion tokens |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `deepseek/deepseek-v4-flash` | 100% | 100% | 100% | 0.163 | 0.065 | 0 | 67,887 | 45,334 | 31,247 |
+| `qwen/qwen3.5-27b` | 60% | 100% | 100% | 0.000 | 0.000 | 0 | 185,908 | 47,026 | 55,949 |
+| `openai/gpt-oss-120b` | 60% | 100% | 100% | 0.144 | 0.069 | 1 | 8,298 | 64,975 | 23,272 |
+| `mistralai/mistral-small-2603` | 20% | 80% | 100% | 0.122 | 0.033 | 0 | 10,963 | 71,569 | 7,088 |
+| `z-ai/glm-5.2` | 80% | 100% | 100% | 0.039 | 0.012 | 0 | 38,930 | 57,631 | 28,190 |
+| `z-ai/glm-4.7-flash` | 20% | 80% | 93% | 0.137 | 0.035 | 0 | 231,562 | 62,423 | 51,287 |
+| `qwen/qwen3.5-35b-a3b` | 0% | 20% | 67% | 0.017 | 0.006 | 0 | 296,394 | 13,405 | 27,592 |
+
+A blinded review of the three fully viable finalists ranked **C > A > B**, where A was `deepseek/deepseek-v4-flash`, B was `openai/gpt-oss-120b`, and C was `z-ai/glm-5.2`. GLM-5.2 gave the best breadth, naming four distinct projects in the technical-range Story, and had zero entailment violations in the reviewed output. GPT-OSS invented a relationship between Noah's self-hosting and the named project evidence. The license check found GLM-5.2 and DeepSeek V4 Flash under MIT, and GPT-OSS 120B under Apache-2.0.
+
+OpenRouter serves GLM-5.2 through endpoints with different quantization and prices. At the time of review, Novita's fp8 endpoint was $0.2968/$0.9328 per million input/output tokens, while other fp4, fp8, and unreported-quantization endpoints ranged as high as $1.05/$4.40 per million. The shootout used OpenRouter auto-routing, so provider pinning can change quality as well as cost; `OPENROUTER_PROVIDER_ORDER` is therefore an optional preference with fallbacks left enabled, not a default or an `only` restriction.
+
+**Decision:** make `z-ai/glm-5.2` the default. It combined 80% first-try and 100% final plan validity with zero banned phrases, much lower repetition than DeepSeek (0.039 versus 0.163 maximum Jaccard), better blinded-review breadth and entailment, and roughly 39 seconds per Story versus DeepSeek's 68 seconds. Keep auto-routing as the zero-configuration path; operators who prefer a known endpoint may set an ordered provider preference and should rerun `scripts/story-model-eval.ts --pipeline` after pinning.

--- a/noah-portfolio/.env.local.example
+++ b/noah-portfolio/.env.local.example
@@ -1,5 +1,8 @@
 OPENROUTER_API_KEY=
-OPENROUTER_MODEL=deepseek/deepseek-v4-flash
+# Default chosen in the 2026-07 shootout: better instruction adherence and a cheaper repetition profile than deepseek-v4-flash; see docs/reviews/2026-07-17-story-output-review.md.
+OPENROUTER_MODEL=z-ai/glm-5.2
+# Optional provider preference; fallbacks remain enabled. Novita was the cheapest GLM-5.2 endpoint at time of writing (fp8, $0.30/$0.93 per M tokens); shootout quality was measured via OpenRouter auto-routing — if you pin a provider, re-verify with scripts/story-model-eval.ts --pipeline since quantization can change quality.
+# OPENROUTER_PROVIDER_ORDER=novita
 CF_ACCOUNT_ID=
 CF_D1_DATABASE_ID=
 CF_D1_TOKEN=

--- a/noah-portfolio/app/api/__tests__/generate.test.ts
+++ b/noah-portfolio/app/api/__tests__/generate.test.ts
@@ -54,6 +54,7 @@ const EVIDENCE = CORPUS_EVIDENCE_REFS.slice(0, 3);
 
 const VALID_PLAN: StoryPlan = {
   question: QUESTION,
+  mode: "grounded",
   backdropPreset: "ambientLava",
   scenes: [
     {
@@ -99,6 +100,12 @@ const VALID_PLAN: StoryPlan = {
     "Which projects best demonstrate that approach?",
     "Which skills does Noah use most often?",
   ],
+};
+
+const ONE_SCENE_PLAN: StoryPlan = {
+  ...VALID_PLAN,
+  mode: "boundary",
+  scenes: [{ ...VALID_PLAN.scenes[0], evidenceRefIds: [] }],
 };
 
 const FIVE_SCENE_PLAN: StoryPlan = {
@@ -328,6 +335,34 @@ describe("POST /api/generate", () => {
     expect(persisted.scenes[2].projects).toEqual(
       resolveStoryProjects(VALID_PLAN.scenes[2].projectSlugs),
     );
+  });
+
+  it("streams, composes, and prepares an uncited one-Scene Boundary Story for publication", async () => {
+    streamTextMock
+      .mockReturnValueOnce(modelResult(JSON.stringify(ONE_SCENE_PLAN)))
+      .mockReturnValueOnce(modelResult(JSON.stringify({ body: "I have not shared that information." })));
+
+    const events = await readEvents(await generate(postRequest({ question: QUESTION })));
+    const sceneEvents = events.filter((event) => event.type === "scene");
+
+    expect(sceneEvents).toHaveLength(1);
+    expect(events.find((event) => event.type === "plan")).toEqual({
+      type: "plan",
+      plan: ONE_SCENE_PLAN,
+      evidence: [],
+    });
+    expect(sceneEvents[0]).toEqual({
+      type: "scene",
+      index: 0,
+      scene: { ...ONE_SCENE_PLAN.scenes[0], body: "I have not shared that information." },
+    });
+    expect(prepareCompleteStoryMock.mock.calls[0][0].scenes).toHaveLength(1);
+    expect(prepareCompleteStoryMock.mock.calls[0][0].evidence).toEqual([]);
+    expect(events.at(-1)).toEqual({
+      type: "phase",
+      phase: "publishing",
+      publicationToken: PUBLICATION_TOKEN,
+    });
   });
 
   it("accepts and preserves the five-Scene upper boundary in Plan order", async () => {

--- a/noah-portfolio/app/api/generate/route.ts
+++ b/noah-portfolio/app/api/generate/route.ts
@@ -144,6 +144,8 @@ function parseSceneBody(output: string): string {
 }
 
 async function composeScene(
+  question: string,
+  storyOutline: readonly Pick<ScenePlan, "index" | "role" | "title" | "claim">[],
   lockedPlan: ScenePlan,
   storyEvidence: ValidatedStoryEvidence,
   signal: AbortSignal,
@@ -157,7 +159,7 @@ async function composeScene(
     let output = "";
     try {
       output = await collectModelText(
-        buildSceneSystemPrompt(lockedPlan, lockedEvidence),
+        buildSceneSystemPrompt(question, storyOutline, lockedPlan, lockedEvidence),
         messages,
         signal,
         storyTelemetry("story-scene", { sceneIndex: lockedPlan.index, attempt }),
@@ -265,8 +267,14 @@ function generationStream(
 
             emit({ type: "phase", phase: "composing" });
             const scenes: StoryScene[] = [];
+            const storyOutline = plan.scenes.map(({ index, role, title, claim }) => ({
+              index,
+              role,
+              title,
+              claim,
+            }));
             for (const lockedScene of plan.scenes) {
-              const scene = await composeScene(lockedScene, evidence, signal);
+              const scene = await composeScene(question, storyOutline, lockedScene, evidence, signal);
               scenes.push(scene);
               emit({ type: "scene", index: scene.index, scene });
             }

--- a/noah-portfolio/app/api/generate/route.ts
+++ b/noah-portfolio/app/api/generate/route.ts
@@ -145,7 +145,7 @@ function parseSceneBody(output: string): string {
 
 async function composeScene(
   question: string,
-  storyOutline: readonly Pick<ScenePlan, "index" | "role" | "title" | "claim">[],
+  scenes: readonly Pick<ScenePlan, "index" | "role" | "title" | "claim">[],
   lockedPlan: ScenePlan,
   storyEvidence: ValidatedStoryEvidence,
   signal: AbortSignal,
@@ -159,7 +159,7 @@ async function composeScene(
     let output = "";
     try {
       output = await collectModelText(
-        buildSceneSystemPrompt(question, storyOutline, lockedPlan, lockedEvidence),
+        buildSceneSystemPrompt(question, scenes, lockedPlan, lockedEvidence),
         messages,
         signal,
         storyTelemetry("story-scene", { sceneIndex: lockedPlan.index, attempt }),
@@ -267,14 +267,8 @@ function generationStream(
 
             emit({ type: "phase", phase: "composing" });
             const scenes: StoryScene[] = [];
-            const storyOutline = plan.scenes.map(({ index, role, title, claim }) => ({
-              index,
-              role,
-              title,
-              claim,
-            }));
             for (const lockedScene of plan.scenes) {
-              const scene = await composeScene(question, storyOutline, lockedScene, evidence, signal);
+              const scene = await composeScene(question, plan.scenes, lockedScene, evidence, signal);
               scenes.push(scene);
               emit({ type: "scene", index: scene.index, scene });
             }

--- a/noah-portfolio/app/benchmark/page.tsx
+++ b/noah-portfolio/app/benchmark/page.tsx
@@ -3,11 +3,17 @@ import Link from 'next/link';
 import { ArrowLeft, CheckCircle2, Gauge, Sparkles } from 'lucide-react';
 import BenchmarkCharts, { type BenchmarkDatum } from '@/components/benchmark/BenchmarkCharts';
 import { ThemeSwitch } from '@/components/ThemeSwitch';
-import { benchmark, costUsdPerStory, pricingSnapshotDates } from '@/lib/benchmark/data';
+import {
+  benchmark,
+  costUsdPerStory,
+  pricingSnapshotDates,
+  runDates,
+  storySampleSizes,
+} from '@/lib/benchmark/data';
 
 export const metadata: Metadata = {
   title: 'Story Pipeline Benchmark | Noah Rijkaard',
-  description: 'A seven-model benchmark of the plan, repair, scene, and validation pipeline behind Noah Rijkaard’s generated Stories.',
+  description: `A ${benchmark.models.length}-model benchmark of the plan, repair, scene, and validation pipeline behind Noah Rijkaard’s generated Stories.`,
 };
 
 const chartModels: BenchmarkDatum[] = benchmark.models.map((model) => ({
@@ -24,12 +30,13 @@ const chartModels: BenchmarkDatum[] = benchmark.models.map((model) => ({
 }));
 
 const winner = benchmark.models.find((model) => model.verdict === 'default');
-const runDate = new Intl.DateTimeFormat('en', {
-  month: 'long',
-  day: 'numeric',
-  year: 'numeric',
-  timeZone: 'UTC',
-}).format(new Date(`${benchmark.runDate}T00:00:00Z`));
+const benchmarkRunDates = runDates(benchmark);
+const sampleSizes = storySampleSizes(benchmark);
+const sampleSizeLabel = sampleSizes.length === 0
+  ? 'Story questions per model'
+  : sampleSizes.length === 1
+    ? `${sampleSizes[0]} Story questions per model`
+    : `${sampleSizes[0]}–${sampleSizes[sampleSizes.length - 1]} Story questions per model`;
 
 export default function BenchmarkPage() {
   return (
@@ -51,13 +58,29 @@ export default function BenchmarkPage() {
         <section aria-labelledby="benchmark-heading" className="grid gap-10 border-b border-border pb-14 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
           <div className="max-w-3xl">
             <p className="font-mono text-xs uppercase tracking-[0.26em] text-muted-foreground">
-              Story pipeline / <time dateTime={benchmark.runDate}>{runDate}</time>
+              Story pipeline /{' '}
+              {benchmarkRunDates.length === 0 ? (
+                'Date unavailable'
+              ) : benchmarkRunDates.length === 1 ? (
+                <time dateTime={benchmarkRunDates[0]}>{benchmarkRunDates[0]}</time>
+              ) : (
+                <>
+                  <time dateTime={benchmarkRunDates[0]}>{benchmarkRunDates[0]}</time>
+                  {' – '}
+                  <time dateTime={benchmarkRunDates[benchmarkRunDates.length - 1]}>
+                    {benchmarkRunDates[benchmarkRunDates.length - 1]}
+                  </time>
+                </>
+              )}
             </p>
             <h1 id="benchmark-heading" className="mt-5 text-balance font-serif text-5xl leading-[0.95] tracking-tight sm:text-6xl lg:text-7xl">
-              Seven models entered the Story pipeline.
+              {benchmark.models.length} model{benchmark.models.length === 1 ? '' : 's'} entered the Story pipeline.
             </h1>
             <p className="mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
-              {benchmark.questionsPerModel} questions per model went through the real plan → repair → scenes pipeline and the app&apos;s own validators. GLM 5.2 won the blinded review and became the default.
+              {sampleSizeLabel} went through the real plan → repair → scenes pipeline and the app&apos;s own validators.{' '}
+              {winner
+                ? `${winner.label} won the blinded review and became the default.`
+                : 'The results below compare every completed run.'}
             </p>
           </div>
 

--- a/noah-portfolio/app/benchmark/page.tsx
+++ b/noah-portfolio/app/benchmark/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowLeft, CheckCircle2, Gauge, Sparkles } from 'lucide-react';
+import BenchmarkCharts, { type BenchmarkDatum } from '@/components/benchmark/BenchmarkCharts';
+import { ThemeSwitch } from '@/components/ThemeSwitch';
+import { benchmark, costUsdPerStory, pricingSnapshotDates } from '@/lib/benchmark/data';
+
+export const metadata: Metadata = {
+  title: 'Story Pipeline Benchmark | Noah Rijkaard',
+  description: 'A seven-model benchmark of the plan, repair, scene, and validation pipeline behind Noah Rijkaard’s generated Stories.',
+};
+
+const chartModels: BenchmarkDatum[] = benchmark.models.map((model) => ({
+  id: model.id,
+  label: model.label,
+  planFirstTryValid: model.planFirstTryValid,
+  planFinalValid: model.planFinalValid,
+  repetitionMax: model.repetitionMax,
+  repetitionMean: model.repetitionMean,
+  bannedPhrases: model.bannedPhrases,
+  meanStoryMs: model.meanStoryMs,
+  costUsdPerStory: costUsdPerStory(model),
+  verdict: model.verdict,
+}));
+
+const winner = benchmark.models.find((model) => model.verdict === 'default');
+const runDate = new Intl.DateTimeFormat('en', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+}).format(new Date(`${benchmark.runDate}T00:00:00Z`));
+
+export default function BenchmarkPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border bg-card">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
+          <Link
+            href="/"
+            className="inline-flex min-h-11 items-center gap-2 rounded-full px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            <ArrowLeft className="size-4" strokeWidth={1.5} aria-hidden />
+            Noah Rijkaard
+          </Link>
+          <div className="w-fit"><ThemeSwitch /></div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-7xl px-5 pb-20 pt-14 sm:px-8 sm:pt-20 lg:pb-28">
+        <section aria-labelledby="benchmark-heading" className="grid gap-10 border-b border-border pb-14 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
+          <div className="max-w-3xl">
+            <p className="font-mono text-xs uppercase tracking-[0.26em] text-muted-foreground">
+              Story pipeline / <time dateTime={benchmark.runDate}>{runDate}</time>
+            </p>
+            <h1 id="benchmark-heading" className="mt-5 text-balance font-serif text-5xl leading-[0.95] tracking-tight sm:text-6xl lg:text-7xl">
+              Seven models entered the Story pipeline.
+            </h1>
+            <p className="mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
+              {benchmark.questionsPerModel} questions per model went through the real plan → repair → scenes pipeline and the app&apos;s own validators. GLM 5.2 won the blinded review and became the default.
+            </p>
+          </div>
+
+          <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-[var(--story-radius-md)] border border-border bg-border">
+            <div className="bg-card p-4">
+              <dt className="font-mono text-[0.6875rem] uppercase tracking-[0.18em] text-muted-foreground">Models</dt>
+              <dd className="mt-2 font-serif text-3xl">{benchmark.models.length}</dd>
+            </div>
+            <div className="bg-card p-4">
+              <dt className="font-mono text-[0.6875rem] uppercase tracking-[0.18em] text-muted-foreground">Stories</dt>
+              <dd className="mt-2 font-serif text-3xl">{benchmark.models.reduce((sum, model) => sum + model.stories, 0)}</dd>
+            </div>
+            <div className="col-span-2 bg-card p-4">
+              <dt className="font-mono text-[0.6875rem] uppercase tracking-[0.18em] text-muted-foreground">Pipeline</dt>
+              <dd className="mt-2 text-sm text-card-foreground">Plan → repair → scenes → validate</dd>
+            </div>
+          </dl>
+        </section>
+
+        {winner ? (
+          <section aria-labelledby="winner-heading" className="my-10 grid gap-6 rounded-[var(--story-radius-md)] border border-border bg-card p-5 shadow-[var(--story-shadow)] sm:p-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+            <div>
+              <p className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-[0.22em] text-chart-2">
+                <Sparkles className="size-4" strokeWidth={1.5} aria-hidden /> Selected default
+              </p>
+              <h2 id="winner-heading" className="mt-3 font-serif text-3xl tracking-tight sm:text-4xl">{winner.label}</h2>
+              <blockquote className="mt-4 max-w-3xl border-l-2 border-chart-2 pl-4 text-base leading-relaxed text-muted-foreground">
+                “{winner.note}”
+              </blockquote>
+            </div>
+            <dl className="grid min-w-64 grid-cols-2 gap-4 text-sm">
+              <div>
+                <dt className="flex items-center gap-2 text-muted-foreground"><CheckCircle2 className="size-4 text-chart-2" strokeWidth={1.5} aria-hidden /> Final plans</dt>
+                <dd className="mt-1 font-mono text-lg">{Math.round(winner.planFinalValid * 100)}%</dd>
+              </div>
+              <div>
+                <dt className="flex items-center gap-2 text-muted-foreground"><Gauge className="size-4 text-chart-1" strokeWidth={1.5} aria-hidden /> Per Story</dt>
+                <dd className="mt-1 font-mono text-lg">{(winner.meanStoryMs / 1000).toFixed(1)} s</dd>
+              </div>
+            </dl>
+          </section>
+        ) : null}
+
+        <BenchmarkCharts
+          models={chartModels}
+          pricingDates={pricingSnapshotDates(benchmark)}
+          pricingNote={benchmark.pricingNote}
+        />
+      </div>
+    </main>
+  );
+}

--- a/noah-portfolio/components/SiteShell.tsx
+++ b/noah-portfolio/components/SiteShell.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { AnimatePresence, MotionConfig, motion, useReducedMotion } from 'framer-motion';
-import { ArrowDown, ArrowUpRight } from 'lucide-react';
+import { ArrowDown, ArrowUpRight, BarChart3 } from 'lucide-react';
 import Hero from './Hero';
 import PortfolioCanvas from './PortfolioCanvas';
 import CompactHeader from './CompactHeader';
@@ -150,6 +151,13 @@ export default function SiteShell() {
             >
               Story <ArrowDown strokeWidth={1.5} className="size-4" aria-hidden />
             </a>
+            <Link
+              className={TOP_CHROME_ACTION_CLASS}
+              href="/benchmark"
+            >
+              <span className="sr-only sm:not-sr-only">Benchmark</span>
+              <BarChart3 strokeWidth={1.5} className="size-4" aria-hidden />
+            </Link>
             <a
               className={TOP_CHROME_ACTION_CLASS}
               href="https://blog.noahrijkaard.com"

--- a/noah-portfolio/components/__tests__/AskMeProvider.test.tsx
+++ b/noah-portfolio/components/__tests__/AskMeProvider.test.tsx
@@ -10,6 +10,7 @@ import { makeStore } from "@/lib/store";
 const evidence = [CORPUS_EVIDENCE_REFS[0], CORPUS_EVIDENCE_REFS[1]];
 const plan: StoryPlan = {
   question: "How does Noah work?",
+  mode: "grounded",
   backdropPreset: "ditherIndigo",
   relatedQuestions: ["What has Noah built?", "How does Noah work?"],
   scenes: [

--- a/noah-portfolio/components/__tests__/PortfolioCanvas.test.tsx
+++ b/noah-portfolio/components/__tests__/PortfolioCanvas.test.tsx
@@ -37,6 +37,7 @@ const SECOND_PUBLICATION_TOKEN = `${SECOND_STORY_ID}.${"B".repeat(43)}`;
 function makePlan(question: string): StoryPlan {
   return {
     question,
+    mode: "grounded",
     backdropPreset: "ditherIndigo",
     relatedQuestions: [
       "Which systems has Noah designed?",

--- a/noah-portfolio/components/benchmark/BenchmarkCharts.tsx
+++ b/noah-portfolio/components/benchmark/BenchmarkCharts.tsx
@@ -89,19 +89,29 @@ function ChartFrame({
 function ScatterChart({ models, pricingDates, pricingNote }: BenchmarkChartsProps) {
   const reducedMotion = Boolean(useReducedMotion());
   const pricedModels = models.filter(
-    (model): model is BenchmarkDatum & { costUsdPerStory: number } => model.costUsdPerStory !== undefined,
+    (model): model is BenchmarkDatum & { costUsdPerStory: number } =>
+      model.costUsdPerStory !== undefined &&
+      model.costUsdPerStory > 0 &&
+      model.meanStoryMs > 0,
   );
-  const xMin = Math.log10(7);
-  const xMax = Math.log10(330);
-  const yMin = Math.log10(0.0009);
-  const yMax = Math.log10(0.036);
+  const speeds = pricedModels.map((model) => model.meanStoryMs / 1000);
+  const costs = pricedModels.map((model) => model.costUsdPerStory);
+  const minSeconds = speeds.length ? Math.min(...speeds) : 1;
+  const maxSeconds = speeds.length ? Math.max(...speeds) : 10;
+  const minCost = costs.length ? Math.min(...costs) : 0.001;
+  const maxCost = costs.length ? Math.max(...costs) : 0.01;
+  const domainPadding = 1.25;
+  const xMin = Math.log10(minSeconds / domainPadding);
+  const xMax = Math.log10(maxSeconds * domainPadding);
+  const yMin = Math.log10(minCost / domainPadding);
+  const yMax = Math.log10(maxCost * domainPadding);
   const plot = { left: 104, right: 836, top: 42, bottom: 432 };
   const x = (seconds: number) =>
     plot.left + ((Math.log10(seconds) - xMin) / (xMax - xMin)) * (plot.right - plot.left);
   const y = (cost: number) =>
     plot.bottom - ((Math.log10(cost) - yMin) / (yMax - yMin)) * (plot.bottom - plot.top);
-  const xTicks = [10, 30, 100, 300];
-  const yTicks = [0.001, 0.003, 0.01, 0.03];
+  const xTicks = [...new Set([minSeconds, Math.sqrt(minSeconds * maxSeconds), maxSeconds])];
+  const yTicks = [...new Set([minCost, Math.sqrt(minCost * maxCost), maxCost])];
 
   return (
     <ChartFrame
@@ -115,7 +125,7 @@ function ScatterChart({ models, pricingDates, pricingNote }: BenchmarkChartsProp
           viewBox="0 0 920 510"
           className="mx-auto h-auto min-w-[46rem] max-w-[57.5rem] w-full"
           role="img"
-          aria-label={`Scatter chart comparing ${pricedModels.length} models by estimated cost and mean time per Story. GPT-OSS 120B is fastest and cheapest; GLM 5.2 is the selected default.`}
+          aria-label={`Scatter chart comparing ${pricedModels.length} priced models by estimated cost and mean time per Story. Point color shows verdict and the outer ring shows final plan validity.`}
         >
           <title>Model cost and latency efficiency frontier</title>
           {yTicks.map((tick) => {
@@ -135,7 +145,7 @@ function ScatterChart({ models, pricingDates, pricingNote }: BenchmarkChartsProp
               <g key={tick}>
                 <line x1={cx} x2={cx} y1={plot.top} y2={plot.bottom} stroke={BORDER} strokeDasharray="4 6" />
                 <text x={cx} y={plot.bottom + 24} textAnchor="middle" fontSize="13" fill={MUTED}>
-                  {tick} s
+                  {formatSeconds(tick * 1000)}
                 </text>
               </g>
             );
@@ -237,8 +247,13 @@ function ScatterChart({ models, pricingDates, pricingNote }: BenchmarkChartsProp
         <caption>Efficiency frontier source data</caption>
         <thead><tr><th>Model</th><th>Time per Story</th><th>Estimated cost per Story</th><th>Final plan validity</th></tr></thead>
         <tbody>
-          {pricedModels.map((model) => (
-            <tr key={model.id}><th>{model.label}</th><td>{formatSeconds(model.meanStoryMs)}</td><td>{formatCost(model.costUsdPerStory)}</td><td>{formatPercent(model.planFinalValid)}</td></tr>
+          {models.map((model) => (
+            <tr key={model.id}>
+              <th>{model.label}</th>
+              <td>{formatSeconds(model.meanStoryMs)}</td>
+              <td>{model.costUsdPerStory === undefined ? 'Not priced' : formatCost(model.costUsdPerStory)}</td>
+              <td>{formatPercent(model.planFinalValid)}</td>
+            </tr>
           ))}
         </tbody>
       </table>
@@ -252,6 +267,11 @@ function ValidityChart({ models }: { models: BenchmarkDatum[] }) {
     (a, b) => b.planFinalValid - a.planFinalValid || b.planFirstTryValid - a.planFirstTryValid,
   );
   const plot = { left: 258, right: 820, top: 54, row: 54 };
+  const plotBottom = plot.top + Math.max(sorted.length - 1, 0) * plot.row + 52;
+  const viewHeight = plotBottom + 28;
+  const maxRescue = sorted.length
+    ? Math.max(...sorted.map((model) => model.planFinalValid - model.planFirstTryValid))
+    : 0;
   const x = (value: number) => plot.left + value * (plot.right - plot.left);
 
   return (
@@ -263,17 +283,17 @@ function ValidityChart({ models }: { models: BenchmarkDatum[] }) {
     >
       <div className="-mx-2 overflow-x-auto px-2 pb-2">
         <svg
-          viewBox="0 0 900 470"
+          viewBox={`0 0 900 ${viewHeight}`}
           className="mx-auto h-auto min-w-[46rem] max-w-[56.25rem] w-full"
           role="img"
-          aria-label={`Dumbbell chart comparing first-try and final plan validity for ${sorted.length} models. The repair loop rescued up to 60 percentage points for a model.`}
+          aria-label={`Dumbbell chart comparing first-try and final plan validity for ${sorted.length} models. The largest observed repair gain is ${Math.round(maxRescue * 100)} percentage points.`}
         >
           <title>First-try versus final plan validity after repair</title>
           {[0, 0.25, 0.5, 0.75, 1].map((tick) => {
             const cx = x(tick);
             return (
               <g key={tick}>
-                <line x1={cx} x2={cx} y1="36" y2="430" stroke={BORDER} strokeDasharray="4 6" />
+                <line x1={cx} x2={cx} y1="36" y2={plotBottom} stroke={BORDER} strokeDasharray="4 6" />
                 <text x={cx} y="24" textAnchor="middle" fontSize="13" fill={MUTED}>{formatPercent(tick)}</text>
               </g>
             );
@@ -348,8 +368,15 @@ function QualityChart({ models }: { models: BenchmarkDatum[] }) {
   const reducedMotion = Boolean(useReducedMotion());
   const sorted = [...models].sort((a, b) => a.repetitionMax - b.repetitionMax);
   const plot = { left: 258, right: 746, top: 56, row: 54 };
-  const maxScale = 0.18;
-  const width = (value: number) => (value / maxScale) * (plot.right - plot.left);
+  const plotBottom = plot.top + Math.max(sorted.length - 1, 0) * plot.row + 52;
+  const viewHeight = plotBottom + 28;
+  const observedMax = Math.max(
+    0,
+    ...sorted.map((model) => Math.max(model.repetitionMax, model.repetitionMean)),
+  );
+  const maxScale = Math.max(0.02, Math.ceil(observedMax / 0.02) * 0.02);
+  const qualityTicks = [0, maxScale / 3, (maxScale * 2) / 3, maxScale];
+  const width = (value: number) => (Math.max(0, value) / maxScale) * (plot.right - plot.left);
 
   return (
     <ChartFrame
@@ -360,18 +387,20 @@ function QualityChart({ models }: { models: BenchmarkDatum[] }) {
     >
       <div className="-mx-2 overflow-x-auto px-2 pb-2">
         <svg
-          viewBox="0 0 900 470"
+          viewBox={`0 0 900 ${viewHeight}`}
           className="mx-auto h-auto min-w-[46rem] max-w-[56.25rem] w-full"
           role="img"
-          aria-label={`Horizontal bar chart comparing repetition and banned phrase counts for ${sorted.length} models. Qwen3.5 27B recorded zero repetition; GPT-OSS 120B was the only model with a banned phrase.`}
+          aria-label={`Horizontal bar chart comparing maximum and mean repetition plus banned phrase counts for ${sorted.length} models. Lower values are better.`}
         >
           <title>Cross-scene repetition and banned phrase quality measures</title>
-          {[0, 0.06, 0.12, 0.18].map((tick) => {
+          {qualityTicks.map((tick) => {
             const cx = plot.left + width(tick);
             return (
               <g key={tick}>
-                <line x1={cx} x2={cx} y1="36" y2="430" stroke={BORDER} strokeDasharray="4 6" />
-                <text x={cx} y="24" textAnchor="middle" fontSize="13" fill={MUTED}>{tick.toFixed(2)}</text>
+                <line x1={cx} x2={cx} y1="36" y2={plotBottom} stroke={BORDER} strokeDasharray="4 6" />
+                <text x={cx} y="24" textAnchor="middle" fontSize="13" fill={MUTED}>
+                  {tick.toFixed(maxScale < 0.1 ? 3 : 2)}
+                </text>
               </g>
             );
           })}

--- a/noah-portfolio/components/benchmark/BenchmarkCharts.tsx
+++ b/noah-portfolio/components/benchmark/BenchmarkCharts.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import type { ModelVerdict } from '@/lib/benchmark/data';
+
+export interface BenchmarkDatum {
+  id: string;
+  label: string;
+  planFirstTryValid: number;
+  planFinalValid: number;
+  repetitionMax: number;
+  repetitionMean: number;
+  bannedPhrases: number;
+  meanStoryMs: number;
+  costUsdPerStory?: number;
+  verdict: ModelVerdict;
+}
+
+interface BenchmarkChartsProps {
+  models: BenchmarkDatum[];
+  pricingDates: string[];
+  pricingNote: string;
+}
+
+const VERDICT_COLOR: Record<ModelVerdict, string> = {
+  default: 'hsl(var(--chart-2))',
+  finalist: 'hsl(var(--chart-1))',
+  eliminated: 'hsl(var(--chart-3))',
+  candidate: 'hsl(var(--chart-4))',
+};
+
+const EASE = [0.2, 0, 0, 1] as const;
+const INK = 'hsl(var(--foreground))';
+const MUTED = 'hsl(var(--muted-foreground))';
+const BORDER = 'hsl(var(--border))';
+const CARD = 'hsl(var(--card))';
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatSeconds(milliseconds: number) {
+  const seconds = milliseconds / 1000;
+  return `${seconds < 100 ? seconds.toFixed(1) : Math.round(seconds)} s`;
+}
+
+function formatCost(value: number) {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  });
+}
+
+function ChartFrame({
+  id,
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  id: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      aria-labelledby={`${id}-heading`}
+      className="rounded-[var(--story-radius-md)] border border-border bg-card p-4 shadow-[var(--story-shadow)] sm:p-6 lg:p-8"
+    >
+      <header className="mb-6 max-w-2xl">
+        <p className="font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground">{eyebrow}</p>
+        <h2 id={`${id}-heading`} className="mt-2 font-serif text-2xl tracking-tight text-card-foreground sm:text-3xl">
+          {title}
+        </h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">{description}</p>
+      </header>
+      <p className="mb-3 font-mono text-xs text-muted-foreground sm:hidden">
+        Swipe horizontally to inspect the full plot.
+      </p>
+      {children}
+    </section>
+  );
+}
+
+function ScatterChart({ models, pricingDates, pricingNote }: BenchmarkChartsProps) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const pricedModels = models.filter(
+    (model): model is BenchmarkDatum & { costUsdPerStory: number } => model.costUsdPerStory !== undefined,
+  );
+  const xMin = Math.log10(7);
+  const xMax = Math.log10(330);
+  const yMin = Math.log10(0.0009);
+  const yMax = Math.log10(0.036);
+  const plot = { left: 104, right: 836, top: 42, bottom: 432 };
+  const x = (seconds: number) =>
+    plot.left + ((Math.log10(seconds) - xMin) / (xMax - xMin)) * (plot.right - plot.left);
+  const y = (cost: number) =>
+    plot.bottom - ((Math.log10(cost) - yMin) / (yMax - yMin)) * (plot.bottom - plot.top);
+  const xTicks = [10, 30, 100, 300];
+  const yTicks = [0.001, 0.003, 0.01, 0.03];
+
+  return (
+    <ChartFrame
+      id="efficiency-frontier"
+      eyebrow="Cost × latency"
+      title="Efficiency frontier"
+      description="Lower and further left is better. Both axes use logarithmic scales; the validity ring shows how many plans survived the repair loop."
+    >
+      <div className="-mx-2 overflow-x-auto px-2 pb-2">
+        <svg
+          viewBox="0 0 920 510"
+          className="mx-auto h-auto min-w-[46rem] max-w-[57.5rem] w-full"
+          role="img"
+          aria-label={`Scatter chart comparing ${pricedModels.length} models by estimated cost and mean time per Story. GPT-OSS 120B is fastest and cheapest; GLM 5.2 is the selected default.`}
+        >
+          <title>Model cost and latency efficiency frontier</title>
+          {yTicks.map((tick) => {
+            const cy = y(tick);
+            return (
+              <g key={tick}>
+                <line x1={plot.left} x2={plot.right} y1={cy} y2={cy} stroke={BORDER} strokeDasharray="4 6" />
+                <text x={plot.left - 14} y={cy + 4} textAnchor="end" fontSize="13" fill={MUTED}>
+                  {formatCost(tick)}
+                </text>
+              </g>
+            );
+          })}
+          {xTicks.map((tick) => {
+            const cx = x(tick);
+            return (
+              <g key={tick}>
+                <line x1={cx} x2={cx} y1={plot.top} y2={plot.bottom} stroke={BORDER} strokeDasharray="4 6" />
+                <text x={cx} y={plot.bottom + 24} textAnchor="middle" fontSize="13" fill={MUTED}>
+                  {tick} s
+                </text>
+              </g>
+            );
+          })}
+          <line x1={plot.left} x2={plot.right} y1={plot.bottom} y2={plot.bottom} stroke={MUTED} />
+          <line x1={plot.left} x2={plot.left} y1={plot.top} y2={plot.bottom} stroke={MUTED} />
+          <text x={(plot.left + plot.right) / 2} y="496" textAnchor="middle" fontSize="14" fill={MUTED}>
+            Mean time per Story · log scale
+          </text>
+          <text
+            x="20"
+            y={(plot.top + plot.bottom) / 2}
+            textAnchor="middle"
+            fontSize="14"
+            fill={MUTED}
+            transform={`rotate(-90 20 ${(plot.top + plot.bottom) / 2})`}
+          >
+            Estimated USD per Story · log scale
+          </text>
+
+          {pricedModels.map((model, index) => {
+            const cx = x(model.meanStoryMs / 1000);
+            const cy = y(model.costUsdPerStory);
+            const radius = 8 + model.planFinalValid * 4;
+            const labelLeft = cx > 650;
+            const labelDy = index % 2 === 0 ? -15 : 24;
+            return (
+              <g key={model.id} data-model-id={model.id}>
+                <circle cx={cx} cy={cy} r={radius} fill="none" stroke={BORDER} strokeWidth="3" />
+                <motion.circle
+                  cx={cx}
+                  cy={cy}
+                  r={radius}
+                  fill="none"
+                  stroke={VERDICT_COLOR[model.verdict]}
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  transform={`rotate(-90 ${cx} ${cy})`}
+                  initial={reducedMotion ? false : { pathLength: 0, opacity: 0 }}
+                  animate={{ pathLength: model.planFinalValid, opacity: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.65, delay: reducedMotion ? 0 : index * 0.04, ease: EASE }}
+                />
+                <motion.circle
+                  cx={cx}
+                  cy={cy}
+                  r="5"
+                  fill={VERDICT_COLOR[model.verdict]}
+                  stroke={CARD}
+                  strokeWidth="2"
+                  initial={reducedMotion ? false : { opacity: 0, scale: 0 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.3, delay: reducedMotion ? 0 : 0.18 + index * 0.04, ease: EASE }}
+                />
+                <text
+                  x={cx + (labelLeft ? -18 : 18)}
+                  y={cy + labelDy}
+                  textAnchor={labelLeft ? 'end' : 'start'}
+                  fontSize="14"
+                  fontWeight="600"
+                  fill={INK}
+                >
+                  {model.label}
+                </text>
+                <text
+                  x={cx + (labelLeft ? -18 : 18)}
+                  y={cy + labelDy + 15}
+                  textAnchor={labelLeft ? 'end' : 'start'}
+                  fontSize="12"
+                  fill={MUTED}
+                >
+                  {formatSeconds(model.meanStoryMs)} · {formatCost(model.costUsdPerStory)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground" aria-label="Verdict legend">
+        {(['default', 'finalist', 'eliminated'] as const).map((verdict) => (
+          <span key={verdict} className="inline-flex items-center gap-2">
+            <span className="size-2.5 rounded-full" style={{ backgroundColor: VERDICT_COLOR[verdict] }} aria-hidden />
+            <span className="capitalize">{verdict}</span>
+          </span>
+        ))}
+        <span>Outer ring = final plan validity</span>
+      </div>
+      <p className="mt-5 border-t border-border pt-4 text-xs leading-relaxed text-muted-foreground">
+        Pricing snapshot{pricingDates.length === 1 ? '' : 's'}:{' '}
+        {pricingDates.length
+          ? pricingDates.map((date, index) => (
+              <span key={date}>
+                <time dateTime={date}>{date}</time>{index < pricingDates.length - 1 ? ', ' : ''}
+              </span>
+            ))
+          : 'not available'}.{' '}
+        {pricingNote}
+      </p>
+      <table className="sr-only">
+        <caption>Efficiency frontier source data</caption>
+        <thead><tr><th>Model</th><th>Time per Story</th><th>Estimated cost per Story</th><th>Final plan validity</th></tr></thead>
+        <tbody>
+          {pricedModels.map((model) => (
+            <tr key={model.id}><th>{model.label}</th><td>{formatSeconds(model.meanStoryMs)}</td><td>{formatCost(model.costUsdPerStory)}</td><td>{formatPercent(model.planFinalValid)}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </ChartFrame>
+  );
+}
+
+function ValidityChart({ models }: { models: BenchmarkDatum[] }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const sorted = [...models].sort(
+    (a, b) => b.planFinalValid - a.planFinalValid || b.planFirstTryValid - a.planFirstTryValid,
+  );
+  const plot = { left: 258, right: 820, top: 54, row: 54 };
+  const x = (value: number) => plot.left + value * (plot.right - plot.left);
+
+  return (
+    <ChartFrame
+      id="repair-rescue"
+      eyebrow="Validation"
+      title="What the repair loop rescued"
+      description="The hollow marker is first-try plan validity; the solid marker is validity after the bounded repair pass."
+    >
+      <div className="-mx-2 overflow-x-auto px-2 pb-2">
+        <svg
+          viewBox="0 0 900 470"
+          className="mx-auto h-auto min-w-[46rem] max-w-[56.25rem] w-full"
+          role="img"
+          aria-label={`Dumbbell chart comparing first-try and final plan validity for ${sorted.length} models. The repair loop rescued up to 60 percentage points for a model.`}
+        >
+          <title>First-try versus final plan validity after repair</title>
+          {[0, 0.25, 0.5, 0.75, 1].map((tick) => {
+            const cx = x(tick);
+            return (
+              <g key={tick}>
+                <line x1={cx} x2={cx} y1="36" y2="430" stroke={BORDER} strokeDasharray="4 6" />
+                <text x={cx} y="24" textAnchor="middle" fontSize="13" fill={MUTED}>{formatPercent(tick)}</text>
+              </g>
+            );
+          })}
+          {sorted.map((model, index) => {
+            const cy = plot.top + index * plot.row;
+            const firstX = x(model.planFirstTryValid);
+            const finalX = x(model.planFinalValid);
+            return (
+              <g key={model.id} data-model-id={model.id}>
+                <text x={plot.left - 18} y={cy + 4} textAnchor="end" fontSize="14" fontWeight="600" fill={INK}>{model.label}</text>
+                <line x1={plot.left} x2={plot.right} y1={cy} y2={cy} stroke={BORDER} />
+                <motion.line
+                  x1={firstX}
+                  y1={cy}
+                  y2={cy}
+                  stroke="hsl(var(--chart-2))"
+                  strokeWidth="4"
+                  strokeLinecap="round"
+                  initial={reducedMotion ? false : { x2: firstX, opacity: 0 }}
+                  animate={{ x2: finalX, opacity: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.55, delay: reducedMotion ? 0 : index * 0.04, ease: EASE }}
+                />
+                <motion.circle
+                  cx={firstX}
+                  cy={cy}
+                  r="8"
+                  fill={CARD}
+                  stroke="hsl(var(--chart-4))"
+                  strokeWidth="3"
+                  initial={reducedMotion ? false : { opacity: 0, scale: 0 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.25, delay: reducedMotion ? 0 : index * 0.04, ease: EASE }}
+                />
+                <motion.circle
+                  cx={finalX}
+                  cy={cy}
+                  r="5"
+                  fill="hsl(var(--chart-2))"
+                  stroke={CARD}
+                  strokeWidth="2"
+                  initial={reducedMotion ? false : { opacity: 0, scale: 0 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.25, delay: reducedMotion ? 0 : 0.18 + index * 0.04, ease: EASE }}
+                />
+                <text x={plot.right + 18} y={cy + 4} fontSize="13" fill={MUTED}>
+                  +{Math.round((model.planFinalValid - model.planFirstTryValid) * 100)} pts
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-5 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-2"><span className="size-3 rounded-full border-[3px] border-chart-4 bg-card" aria-hidden /> First try</span>
+        <span className="inline-flex items-center gap-2"><span className="size-2.5 rounded-full bg-chart-2" aria-hidden /> After repair</span>
+      </div>
+      <table className="sr-only">
+        <caption>Plan validity before and after repair</caption>
+        <thead><tr><th>Model</th><th>First try</th><th>After repair</th><th>Gain</th></tr></thead>
+        <tbody>
+          {sorted.map((model) => (
+            <tr key={model.id}><th>{model.label}</th><td>{formatPercent(model.planFirstTryValid)}</td><td>{formatPercent(model.planFinalValid)}</td><td>{Math.round((model.planFinalValid - model.planFirstTryValid) * 100)} percentage points</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </ChartFrame>
+  );
+}
+
+function QualityChart({ models }: { models: BenchmarkDatum[] }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const sorted = [...models].sort((a, b) => a.repetitionMax - b.repetitionMax);
+  const plot = { left: 258, right: 746, top: 56, row: 54 };
+  const maxScale = 0.18;
+  const width = (value: number) => (value / maxScale) * (plot.right - plot.left);
+
+  return (
+    <ChartFrame
+      id="quality-fingerprint"
+      eyebrow="Language quality"
+      title="Quality fingerprint"
+      description="Cross-scene body-token Jaccard similarity and banned filler phrases. Lower is better on every measure."
+    >
+      <div className="-mx-2 overflow-x-auto px-2 pb-2">
+        <svg
+          viewBox="0 0 900 470"
+          className="mx-auto h-auto min-w-[46rem] max-w-[56.25rem] w-full"
+          role="img"
+          aria-label={`Horizontal bar chart comparing repetition and banned phrase counts for ${sorted.length} models. Qwen3.5 27B recorded zero repetition; GPT-OSS 120B was the only model with a banned phrase.`}
+        >
+          <title>Cross-scene repetition and banned phrase quality measures</title>
+          {[0, 0.06, 0.12, 0.18].map((tick) => {
+            const cx = plot.left + width(tick);
+            return (
+              <g key={tick}>
+                <line x1={cx} x2={cx} y1="36" y2="430" stroke={BORDER} strokeDasharray="4 6" />
+                <text x={cx} y="24" textAnchor="middle" fontSize="13" fill={MUTED}>{tick.toFixed(2)}</text>
+              </g>
+            );
+          })}
+          <text x="806" y="24" textAnchor="middle" fontSize="13" fill={MUTED}>Banned</text>
+          {sorted.map((model, index) => {
+            const cy = plot.top + index * plot.row;
+            const maxWidth = width(model.repetitionMax);
+            const meanWidth = width(model.repetitionMean);
+            return (
+              <g key={model.id} data-model-id={model.id}>
+                <text x={plot.left - 18} y={cy + 4} textAnchor="end" fontSize="14" fontWeight="600" fill={INK}>{model.label}</text>
+                <line x1={plot.left} x2={plot.right} y1={cy} y2={cy} stroke={BORDER} strokeWidth="8" strokeLinecap="round" />
+                <motion.rect
+                  x={plot.left}
+                  y={cy - 4}
+                  height="8"
+                  rx="4"
+                  fill="hsl(var(--chart-3))"
+                  initial={reducedMotion ? false : { width: 0, opacity: 0 }}
+                  animate={{ width: maxWidth, opacity: 0.5 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.5, delay: reducedMotion ? 0 : index * 0.04, ease: EASE }}
+                />
+                <motion.line
+                  x1={plot.left}
+                  y1={cy}
+                  y2={cy}
+                  stroke="hsl(var(--chart-1))"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  initial={reducedMotion ? false : { x2: plot.left, opacity: 0 }}
+                  animate={{ x2: plot.left + meanWidth, opacity: 1 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.5, delay: reducedMotion ? 0 : 0.12 + index * 0.04, ease: EASE }}
+                />
+                <circle cx={plot.left + maxWidth} cy={cy} r="5" fill="hsl(var(--chart-3))" />
+                <circle cx={plot.left + meanWidth} cy={cy} r="3.5" fill="hsl(var(--chart-1))" stroke={CARD} strokeWidth="1.5" />
+                <circle
+                  cx="806"
+                  cy={cy}
+                  r="7"
+                  fill={model.bannedPhrases ? 'hsl(var(--destructive))' : CARD}
+                  stroke={model.bannedPhrases ? 'hsl(var(--destructive))' : BORDER}
+                  strokeWidth="2"
+                />
+                <text x="824" y={cy + 4} fontSize="13" fill={MUTED}>{model.bannedPhrases}</text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-5 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-2"><span className="h-2 w-5 rounded-full bg-chart-3 opacity-50" aria-hidden /> Maximum Jaccard</span>
+        <span className="inline-flex items-center gap-2"><span className="h-1 w-5 rounded-full bg-chart-1" aria-hidden /> Mean Jaccard</span>
+        <span>Right marker = banned phrase count</span>
+      </div>
+      <table className="sr-only">
+        <caption>Repetition and banned phrase measures</caption>
+        <thead><tr><th>Model</th><th>Maximum Jaccard</th><th>Mean Jaccard</th><th>Banned phrases</th></tr></thead>
+        <tbody>
+          {sorted.map((model) => (
+            <tr key={model.id}><th>{model.label}</th><td>{model.repetitionMax.toFixed(3)}</td><td>{model.repetitionMean.toFixed(3)}</td><td>{model.bannedPhrases}</td></tr>
+          ))}
+        </tbody>
+      </table>
+    </ChartFrame>
+  );
+}
+
+export default function BenchmarkCharts(props: BenchmarkChartsProps) {
+  return (
+    <div className="space-y-8">
+      <ScatterChart {...props} />
+      <ValidityChart models={props.models} />
+      <QualityChart models={props.models} />
+    </div>
+  );
+}

--- a/noah-portfolio/components/story/StoryExperience.tsx
+++ b/noah-portfolio/components/story/StoryExperience.tsx
@@ -346,7 +346,18 @@ function StoryRail({ plan, readyCount, activeIndex, onNavigate }: StoryRailProps
                   onClick={() => onNavigate(index)}
                 >
                   <span className="story-rail__index">{String(index + 1).padStart(2, '0')}</span>
-                  <span className="story-rail__title">{scene.title}</span>
+                  <span
+                    className="story-rail__title"
+                    title={scene.title}
+                    style={{
+                      display: '-webkit-box',
+                      WebkitBoxOrient: 'vertical',
+                      WebkitLineClamp: 2,
+                      whiteSpace: 'normal',
+                    }}
+                  >
+                    {scene.title}
+                  </span>
                   <span className="sr-only">
                     {ready ? (active ? ', active Scene' : ', ready Scene') : ', pending Scene'}
                   </span>
@@ -472,11 +483,13 @@ function StorySceneSection({
   plan,
   cue,
   evidenceById,
+  evidence,
 }: {
   scene: StoryScene;
   plan: StoryPlan;
   cue: StoryPlan['scenes'][number]['cue'];
   evidenceById: Map<string, EvidenceRef>;
+  evidence: readonly Pick<EvidenceRef, 'id' | 'label'>[];
 }) {
   const titleId = `story-scene-title-${scene.index + 1}`;
 
@@ -496,6 +509,7 @@ function StorySceneSection({
           <RemotionScene
             scene={scene}
             plan={plan}
+            evidence={evidence}
             fallback={<MotionAsset assetId={scene.assetId} />}
           />
 
@@ -560,6 +574,10 @@ export default function StoryExperience({
   useBackdropCue(plan, activeIndex);
   const evidenceById = useMemo(
     () => new Map(evidence.map((evidenceRef) => [evidenceRef.id, evidenceRef])),
+    [evidence],
+  );
+  const compositionEvidence = useMemo(
+    () => evidence.map(({ id, label }) => ({ id, label })),
     [evidence],
   );
 
@@ -683,6 +701,7 @@ export default function StoryExperience({
               plan={plan}
               cue={plan.scenes[scene.index].cue}
               evidenceById={evidenceById}
+              evidence={compositionEvidence}
             />
           </Fragment>
         ))}
@@ -722,10 +741,12 @@ export default function StoryExperience({
               </button>
             ))}
           </div>
-          <p className="story-related__complete">
-            <Check aria-hidden="true" />
-            Grounded in {story.evidence.length} evidence {story.evidence.length === 1 ? 'reference' : 'references'}
-          </p>
+          {story.evidence.length > 0 ? (
+            <p className="story-related__complete">
+              <Check aria-hidden="true" />
+              Grounded in {story.evidence.length} evidence {story.evidence.length === 1 ? 'reference' : 'references'}
+            </p>
+          ) : null}
         </footer>
       ) : null}
     </article>

--- a/noah-portfolio/components/story/StoryExperience.tsx
+++ b/noah-portfolio/components/story/StoryExperience.tsx
@@ -576,10 +576,6 @@ export default function StoryExperience({
     () => new Map(evidence.map((evidenceRef) => [evidenceRef.id, evidenceRef])),
     [evidence],
   );
-  const compositionEvidence = useMemo(
-    () => evidence.map(({ id, label }) => ({ id, label })),
-    [evidence],
-  );
 
   useEffect(() => setShareStatus(''), [question]);
 
@@ -701,7 +697,7 @@ export default function StoryExperience({
               plan={plan}
               cue={plan.scenes[scene.index].cue}
               evidenceById={evidenceById}
-              evidence={compositionEvidence}
+              evidence={evidence}
             />
           </Fragment>
         ))}

--- a/noah-portfolio/components/story/__tests__/EvidenceLedger.test.ts
+++ b/noah-portfolio/components/story/__tests__/EvidenceLedger.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getEvidenceLedgerRows } from "@/components/story/remotion/compositions/EvidenceLedger";
+
+describe("getEvidenceLedgerRows", () => {
+  it("renders human evidence labels instead of de-dashed IDs", () => {
+    expect(
+      getEvidenceLedgerRows(
+        ["openrouter-model-routing", "missing-evidence"],
+        [{ id: "openrouter-model-routing", label: "OpenRouter model routing" }],
+      ),
+    ).toEqual(["OpenRouter model routing", "missing evidence"]);
+  });
+});

--- a/noah-portfolio/components/story/__tests__/StoryExperience.test.tsx
+++ b/noah-portfolio/components/story/__tests__/StoryExperience.test.tsx
@@ -56,6 +56,7 @@ const QUESTION = "How does Noah approach production systems?";
 function makePlan(): StoryPlan {
   return {
     question: QUESTION,
+    mode: "grounded",
     backdropPreset: "ditherIndigo",
     relatedQuestions: [
       "Which systems has Noah designed?",
@@ -249,6 +250,38 @@ describe("StoryExperience", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("status", { name: "Story generation status" })).not.toBeInTheDocument();
     expect(document.querySelector(".story-phase-pill")).not.toBeInTheDocument();
+  });
+
+  it("renders a complete single-scene Story without a transition or synthesis", () => {
+    const plan = makePlan();
+    plan.mode = "boundary";
+    plan.scenes[0].evidenceRefIds = [];
+    plan.scenes = [plan.scenes[0]];
+    const story = makeStory(plan);
+    story.evidence = [];
+
+    render(
+      <StoryExperience
+        question={QUESTION}
+        phase="publishing"
+        plan={story.plan}
+        scenes={story.scenes}
+        evidence={story.evidence}
+        story={story}
+        error={null}
+        onRetry={vi.fn()}
+        onRelatedQuestion={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelectorAll("section[data-story-scene]")).toHaveLength(1);
+    expect(screen.getByRole("navigation", { name: "Story scenes" }).querySelectorAll("li")).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Sources for this claim" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grounded in 0 evidence references/i)).not.toBeInTheDocument();
+    expect(screen.getByText("1 of 1 ready")).toBeInTheDocument();
+    expect(screen.queryByTestId("scene-transition")).not.toBeInTheDocument();
+    expect(screen.getByText("Direct answer")).toBeInTheDocument();
+    expect(screen.queryByText("Synthesis")).not.toBeInTheDocument();
   });
 
   it("swaps complete Prelude phrases without typewriter motion when reduced motion is preferred", async () => {

--- a/noah-portfolio/components/story/remotion/RemotionScene.tsx
+++ b/noah-portfolio/components/story/remotion/RemotionScene.tsx
@@ -4,6 +4,7 @@ import { Component, Suspense, lazy, useEffect, useRef, useState, type ReactNode 
 import { useReducedMotion } from "framer-motion";
 
 import type { StoryPlan, StoryScene } from "@/lib/story/types";
+import type { SceneCompositionProps } from "@/components/story/remotion/contract";
 
 // Runtime-gated chunk: reduced-motion Stories never pay for the Remotion runtime.
 const LazyScenePlayer = lazy(() => import("@/components/story/remotion/ScenePlayer"));
@@ -11,6 +12,7 @@ const LazyScenePlayer = lazy(() => import("@/components/story/remotion/ScenePlay
 interface RemotionSceneProps {
   scene: StoryScene;
   plan: StoryPlan;
+  evidence: SceneCompositionProps["evidence"];
   /** Static rendering used for reduced motion, runtime failure, and Suspense. */
   fallback: ReactNode;
 }
@@ -31,7 +33,7 @@ class CompositionBoundary extends Component<
 }
 
 /** Plays a Scene's pattern composition while it is on screen; pauses off screen. */
-export function RemotionScene({ scene, plan, fallback }: RemotionSceneProps) {
+export function RemotionScene({ scene, plan, evidence, fallback }: RemotionSceneProps) {
   const reducedMotion = Boolean(useReducedMotion());
   const hostRef = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
@@ -60,7 +62,7 @@ export function RemotionScene({ scene, plan, fallback }: RemotionSceneProps) {
     >
       <CompositionBoundary fallback={fallback}>
         <Suspense fallback={fallback}>
-          <LazyScenePlayer scene={scene} plan={plan} playing={inView} />
+          <LazyScenePlayer scene={scene} plan={plan} evidence={evidence} playing={inView} />
         </Suspense>
       </CompositionBoundary>
     </div>

--- a/noah-portfolio/components/story/remotion/ScenePlayer.tsx
+++ b/noah-portfolio/components/story/remotion/ScenePlayer.tsx
@@ -15,6 +15,7 @@ import { SCENE_COMPOSITIONS } from "@/components/story/remotion/registry";
 export interface ScenePlayerProps {
   scene: StoryScene;
   plan: StoryPlan;
+  evidence: SceneCompositionProps["evidence"];
   playing: boolean;
 }
 
@@ -23,10 +24,10 @@ export interface ScenePlayerProps {
  * stays a lazily loaded chunk. `lazy()` cannot carry Player's generic, so the
  * generic is bound here instead of in RemotionScene.
  */
-export default function ScenePlayer({ scene, plan, playing }: ScenePlayerProps) {
+export default function ScenePlayer({ scene, plan, evidence, playing }: ScenePlayerProps) {
   const playerRef = useRef<PlayerRef>(null);
   const entry = SCENE_COMPOSITIONS[scene.pattern];
-  const inputProps: SceneCompositionProps = { scene, plan };
+  const inputProps: SceneCompositionProps = { scene, plan, evidence };
 
   // Playback is driven imperatively from visibility. `autoPlay` is snapshotted
   // once at mount, so it can never track visibility changes.

--- a/noah-portfolio/components/story/remotion/compositions/EvidenceLedger.tsx
+++ b/noah-portfolio/components/story/remotion/compositions/EvidenceLedger.tsx
@@ -135,12 +135,26 @@ function VerifiedMark() {
   );
 }
 
-export default function EvidenceLedger({ scene }: SceneCompositionProps) {
+const MAX_ROW_LABEL_LENGTH = 72;
+
+export function getEvidenceLedgerRows(
+  evidenceRefIds: readonly string[],
+  evidence: SceneCompositionProps["evidence"],
+) {
+  const labelsById = new Map(evidence.map(({ id, label }) => [id, label.trim()]));
+
+  return evidenceRefIds.slice(0, 8).map((id) => {
+    const label = labelsById.get(id) || id.replaceAll("-", " ");
+    return label.length > MAX_ROW_LABEL_LENGTH
+      ? `${label.slice(0, MAX_ROW_LABEL_LENGTH - 1).trimEnd()}…`
+      : label;
+  });
+}
+
+export default function EvidenceLedger({ scene, evidence }: SceneCompositionProps) {
   const frame = useCurrentFrame();
   const { durationInFrames } = useVideoConfig();
-  const rows = scene.evidenceRefIds
-    .slice(0, 8)
-    .map((id) => id.replaceAll("-", " "));
+  const rows = getEvidenceLedgerRows(scene.evidenceRefIds, evidence);
   const firstRowFrame = 42;
   const rowStagger = 22;
   const finalBeatFrame = firstRowFrame + rows.length * rowStagger + 28;
@@ -176,7 +190,7 @@ export default function EvidenceLedger({ scene }: SceneCompositionProps) {
           position: "absolute",
           top: 48,
           right: 64,
-          left: 64,
+          left: 184,
           display: "flex",
           alignItems: "flex-end",
           justifyContent: "flex-start",
@@ -198,6 +212,10 @@ export default function EvidenceLedger({ scene }: SceneCompositionProps) {
           </p>
           <h1
             style={{
+              display: "-webkit-box",
+              overflow: "hidden",
+              WebkitBoxOrient: "vertical",
+              WebkitLineClamp: 2,
               margin: "8px 0 0",
               fontFamily: "var(--story-display-font)",
               fontSize: 50,

--- a/noah-portfolio/components/story/remotion/compositions/NightDrive.tsx
+++ b/noah-portfolio/components/story/remotion/compositions/NightDrive.tsx
@@ -220,7 +220,7 @@ export default function NightDrive({ scene, plan }: SceneCompositionProps) {
               textTransform: "uppercase",
             }}
           >
-            Night drive · {String(scene.index + 1).padStart(2, "0")}
+            Timeline · {String(scene.index + 1).padStart(2, "0")}
           </div>
           <div
             style={{

--- a/noah-portfolio/components/story/remotion/compositions/SystemAssembly.tsx
+++ b/noah-portfolio/components/story/remotion/compositions/SystemAssembly.tsx
@@ -155,19 +155,21 @@ function Connector({ from, to }: ConnectorProps) {
   );
 }
 
-export default function SystemAssembly({ scene, plan }: SceneCompositionProps) {
+export default function SystemAssembly({ scene, plan, evidence }: SceneCompositionProps) {
   const frame = useCurrentFrame();
   const { durationInFrames } = useVideoConfig();
-  const evidenceLabels = scene.evidenceRefIds
-    .slice(0, 6)
-    .map((id) => id.replaceAll("-", " "));
-  const beatLabels = plan.scenes.map(({ title }) => title);
-  const candidates = evidenceLabels.length >= 3 ? [...evidenceLabels, ...beatLabels] : beatLabels;
-  const labels = [...new Set(candidates)].slice(0, 6);
-  while (labels.length < 4) {
-    const beat = plan.scenes[labels.length % plan.scenes.length];
-    labels.push(`${beat.title} / ${beat.role.replaceAll("-", " ")}`);
-  }
+  const evidenceById = new Map(evidence.map(({ id, label }) => [id, label]));
+  const evidenceLabels = scene.evidenceRefIds.flatMap((id) => {
+    const label = evidenceById.get(id);
+    return label ? [label] : [];
+  });
+  const otherSceneTitles = plan.scenes
+    .filter(({ id }) => id !== scene.id)
+    .map(({ title }) => title);
+  const labels = [...new Set([...evidenceLabels, ...otherSceneTitles])].slice(
+    0,
+    POSITIONS.length,
+  );
   const nodes = labels.map((label, index) => ({ label, position: POSITIONS[index] }));
   const hubIndex = Math.min(2, nodes.length - 1);
   const edges = nodes

--- a/noah-portfolio/components/story/remotion/contract.ts
+++ b/noah-portfolio/components/story/remotion/contract.ts
@@ -8,6 +8,7 @@ import type { StoryPlan, StoryScene } from "@/lib/story/types";
 export type SceneCompositionProps = {
   scene: StoryScene;
   plan: StoryPlan;
+  evidence: readonly { id: string; label: string }[];
 };
 
 export const SCENE_COMPOSITION_FPS = 30;

--- a/noah-portfolio/content/about-me/projects/story-model-benchmark.md
+++ b/noah-portfolio/content/about-me/projects/story-model-benchmark.md
@@ -1,0 +1,19 @@
+---
+title: "Story Model Benchmark"
+image: "/story-model-benchmark-cover.svg"
+url: "https://my-portfolio-originalbyteme.vercel.app/benchmark"
+technologies:
+  - name: "Next.js"
+    lightIcon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg"
+    darkIcon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-plain.svg"
+  - name: "TypeScript"
+    lightIcon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg"
+    darkIcon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-plain.svg"
+  - name: "Zod"
+    lightIcon: "https://cdn.jsdelivr.net/gh/colinhacks/zod/logo.svg"
+    darkIcon: "https://cdn.jsdelivr.net/gh/colinhacks/zod/logo.svg"
+description: >-
+  I built a repeatable shootout for the portfolio's Story-generation models. It sends five fixed portfolio questions to each model through the production plan generation, one JSON-repair retry, and scene-composition pipeline, then applies the same Zod validators as the live app, checking schema shape and evidence references against a locked corpus vocabulary. It records first-try and after-repair plan validity, scene validity, cross-scene repetition using body-token Jaccard similarity, banned filler phrases, per-Story latency, token use, and estimated cost. The cases exercise malformed JSON, invalid project slugs, duplicate Scene Patterns, and out-of-vocabulary evidence references; semantic grounding is judged separately by a blinded manual review of the finalists. In July 2026 I ran seven OpenRouter models; that review selected GLM-5.2, which is now the application default.
+---
+
+A production-pipeline benchmark for choosing the portfolio's Story-generation model with validity, grounding, repetition, latency, token, and estimated-cost evidence.

--- a/noah-portfolio/docs/story-model-benchmark.md
+++ b/noah-portfolio/docs/story-model-benchmark.md
@@ -1,0 +1,95 @@
+# Story model benchmark
+
+The Story model benchmark compares models on the production Story path rather than on isolated prompts. The planner was the unreliable step: several models produced valid scenes once a plan survived, but first-attempt plan validity ranged from 0% to 100%. A useful model therefore has to produce a valid, grounded plan, recover from one repair request, compose every locked scene, and avoid repetitive or unsupported prose at acceptable latency and cost.
+
+The recorded run is `story-pipeline`, dated 2026-07-18. It sent five fixed questions to each of seven OpenRouter models.
+
+## Questions
+
+1. `How does Noah turn complex systems into products?`
+2. `Which projects best show Noah's technical range?`
+3. `What experience does Noah bring to product engineering?`
+4. `How does Noah combine design thinking with engineering?`
+5. `Which technologies and systems does Noah work with?`
+
+These are the `QUESTIONS` in `scripts/story-model-eval.ts`. Keep the list fixed when comparing models.
+
+## Pipeline
+
+For each question, the evaluator:
+
+1. Generates a Story Plan with the production system and user prompts.
+2. Removes a single outer JSON fence with `stripFences`, parses the JSON, and validates the plan.
+3. If parsing or validation fails, sends the output and error back once and validates the repaired plan. There are at most two plan attempts.
+4. Locks the accepted plan and its exact Evidence vocabulary, then composes its scenes. A failed scene also gets one repair attempt.
+5. Validates each scene against the locked plan and canonical corpus records before recording quality and usage metrics.
+
+`lib/story/validation.ts` performs server-side validation against the exact active Corpus, including canonical Evidence excerpts and trusted project records. `lib/story/public-validation.ts` contains the client-safe structural and semantic invariants: known Evidence IDs, locked Scene fields, unique Scene Patterns, role and cue ordering, and resolved-project correspondence. Both use the Zod contracts in `lib/story/types.ts`; the evaluator imports the same validators used by the live application.
+
+## Metrics and denominators
+
+- **Plan first-try valid:** plans valid on attempt 1 / Stories attempted.
+- **Plan final valid:** plans valid after the optional repair / Stories attempted.
+- **Scenes valid:** valid scene cases after the optional repair / scene cases attempted. A Story whose plan never validates contributes no scene cases.
+- **Repetition max:** for each measured Story, the maximum pairwise Jaccard similarity across scene bodies; the reported value is the sum of those per-Story maxima / measured Stories.
+- **Repetition mean:** for each measured Story, the mean pairwise Jaccard similarity across scene bodies; the reported value is the sum of those per-Story means / measured Stories.
+- **Banned phrases:** total case-insensitive occurrences across all generated scene bodies; there is no rate denominator.
+- **Mean Story latency:** total wall-clock time for all attempted Stories / Stories attempted. This includes plan and scene attempts.
+- **Prompt and completion tokens:** totals across the complete model run. Divide either total, or their sum, by `stories` for per-Story values.
+
+Repetition tokenizes lowercased Unicode letters and numbers, forms three-token body shingles, and computes intersection / union for every pair of scenes. Lower is better. A one-scene Story has no pairs and records zero.
+
+The banned list is imported from `lib/llm/prompt.ts`, so measurement and generation rules share one source. At this run it contained: `technical depth`, `clear product story`, `passionate`, `seamless`, `leveraging`, `showcase`, `aligning`, `robust`, `cutting-edge`, `The bigger picture`, `Impact`, `Synthesis of Skills`, `Why This Stack Matters`, `Making Things That Matter`, `shows the kind of work I do`, `ability to work across`, `core part of my identity`, `bridging prototyping with production`, `Current Role`, and `Full-Stack Range`. Add or remove phrases in `lib/llm/prompt.ts`, not in the evaluator.
+
+## Failure cases
+
+The benchmark path and Story validators catch the failures that caused the plan step to be flaky:
+
+- Fenced JSON is normalized by `stripFences`; malformed JSON fails parsing and enters the single repair attempt.
+- An unknown `projectSlugs` value such as `invented-project`, or a duplicate slug, fails before model-authored project data can reach a scene.
+- Reusing a Scene Pattern in one plan fails the semantic uniqueness check even when the object is otherwise schema-valid.
+- Evidence IDs must exist in the supplied vocabulary. Server validation also compares every Evidence path, label, and excerpt with the active Corpus; replacing an excerpt with model-authored text throws an active-vocabulary error.
+- Boundary questions remain part of the quality problem. For example, `What car does Noah drive?` has no supporting corpus fact. The corrected production behavior is one boundary scene with no Evidence instead of a guessed vehicle or unrelated portfolio detour.
+- Blinded review remains necessary after validator success. One finalist invented a relationship between self-hosting and named project evidence even though its output was structurally valid; that entailment failure counted against it.
+
+## Cost model
+
+Costs are estimates, not measured spend. For each model, the page multiplies run-level prompt and completion token totals by the input and output rates in the pricing snapshot, then divides by Stories attempted.
+
+> Costs are estimates: run token totals × one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary materially.
+
+The snapshot is dated by `pricedAt` in `lib/benchmark/results.json`. Auto-routing can select endpoints with different quantization, quality, and prices; at review time GLM-5.2 endpoints ranged from $0.2968/$0.9328 to $1.05/$4.40 per million input/output tokens. Do not present the result as an invoice or exact provider spend.
+
+## Running it for a future model
+
+Set `OPENROUTER_API_KEY`, then run the full production-pipeline comparison:
+
+```bash
+npm run eval -- --pipeline --models vendor/new-model --out lib/benchmark/results.json
+```
+
+`--models` accepts one OpenRouter slug or a comma-separated list. `--out` merges results by model ID into `lib/benchmark/results.json` and preserves existing editorial verdicts. The `/benchmark` charts import that file and update on the next build.
+
+The canonical loop is:
+
+1. Rerun the evaluator with the model slug and `--out lib/benchmark/results.json`.
+2. Review the merged row and perform a blinded output review before changing its verdict.
+3. Build the site; `/benchmark` reads the updated results without a manual chart edit.
+
+Use `--quick` to run only the first fixed question while checking credentials or a new slug. Use `--self-test` for the deterministic repetition and model-resolution checks; it does not call a model.
+
+`CACTUS_BASE_URL` is **not currently implemented** by `scripts/story-model-eval.ts` or `lib/llm/openrouter.ts`; setting it has no effect. The evaluator currently constructs an OpenRouter provider directly and requires `OPENROUTER_API_KEY`. A non-OpenRouter local endpoint needs an explicit provider/base-URL seam before it can use this harness.
+
+## 2026-07-18 results
+
+| Model | Plan first-try valid | Plan final valid | Scenes valid | Repetition max | Repetition mean | Banned phrases | Mean Story ms | Prompt tokens | Completion tokens |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `deepseek/deepseek-v4-flash` | 100% | 100% | 100% | 0.163 | 0.065 | 0 | 67,887 | 45,334 | 31,247 |
+| `qwen/qwen3.5-27b` | 60% | 100% | 100% | 0.000 | 0.000 | 0 | 185,908 | 47,026 | 55,949 |
+| `openai/gpt-oss-120b` | 60% | 100% | 100% | 0.144 | 0.069 | 1 | 8,298 | 64,975 | 23,272 |
+| `mistralai/mistral-small-2603` | 20% | 80% | 100% | 0.122 | 0.033 | 0 | 10,963 | 71,569 | 7,088 |
+| `z-ai/glm-5.2` | 80% | 100% | 100% | 0.039 | 0.012 | 0 | 38,930 | 57,631 | 28,190 |
+| `z-ai/glm-4.7-flash` | 20% | 80% | 93% | 0.137 | 0.035 | 0 | 231,562 | 62,423 | 51,287 |
+| `qwen/qwen3.5-35b-a3b` | 0% | 20% | 67% | 0.017 | 0.006 | 0 | 296,394 | 13,405 | 27,592 |
+
+A blinded review ranked the viable finalists **C > A > B**: A was DeepSeek V4 Flash, B was GPT-OSS 120B, and C was GLM-5.2. GLM-5.2 covered the broadest set of projects and had no entailment violations in the reviewed output. It also combined 80% first-try and 100% final plan validity, zero banned phrases, 0.039 maximum repetition, and about 39 seconds per Story. DeepSeek repeated more and took about 68 seconds; GPT-OSS was much faster but used a banned phrase and invented an evidence relationship. GLM-5.2 and DeepSeek were MIT-licensed; GPT-OSS was Apache-2.0. The review selected `z-ai/glm-5.2` as the application default while retaining OpenRouter auto-routing unless an operator deliberately sets a provider order and reruns the benchmark.

--- a/noah-portfolio/lib/__tests__/env.test.ts
+++ b/noah-portfolio/lib/__tests__/env.test.ts
@@ -10,6 +10,7 @@ import {
 beforeEach(() => {
   vi.stubEnv("OPENROUTER_API_KEY", "test-key");
   vi.stubEnv("OPENROUTER_MODEL", "");
+  vi.stubEnv("OPENROUTER_PROVIDER_ORDER", undefined);
   vi.stubEnv("CF_ACCOUNT_ID", "");
   vi.stubEnv("STORY_CACHE_HMAC_KEY", "");
   vi.stubEnv("STORY_CACHE_HMAC_KEY_ID", "");
@@ -26,8 +27,30 @@ afterEach(() => {
 
 describe("LLM environment", () => {
   it("defaults the model when unset", () => {
-    expect(getServerEnv().openrouterModel).toBe("deepseek/deepseek-v4-flash");
+    expect(getServerEnv().openrouterModel).toBe("z-ai/glm-5.2");
   });
+
+  it("leaves provider order unset by default", () => {
+    expect(getServerEnv().openrouterProviderOrder).toBeUndefined();
+  });
+
+  it("parses a CSV provider order", () => {
+    vi.stubEnv("OPENROUTER_PROVIDER_ORDER", "novita,deepinfra");
+    expect(getServerEnv().openrouterProviderOrder).toEqual(["novita", "deepinfra"]);
+  });
+
+  it("trims provider-order whitespace", () => {
+    vi.stubEnv("OPENROUTER_PROVIDER_ORDER", " novita , deepinfra ");
+    expect(getServerEnv().openrouterProviderOrder).toEqual(["novita", "deepinfra"]);
+  });
+
+  it.each(["novita,,deepinfra", "novita,", "   "])(
+    "rejects empty provider-order entries in %j",
+    (providerOrder) => {
+      vi.stubEnv("OPENROUTER_PROVIDER_ORDER", providerOrder);
+      expect(() => getServerEnv()).toThrow(/must not contain empty entries/);
+    },
+  );
 
   it("throws when the API key is missing", () => {
     vi.stubEnv("OPENROUTER_API_KEY", "");

--- a/noah-portfolio/lib/benchmark/data.ts
+++ b/noah-portfolio/lib/benchmark/data.ts
@@ -40,13 +40,12 @@ export interface BenchmarkModel {
   pricing?: ModelPricing;
   verdict: ModelVerdict;
   note: string;
+  /** ISO date this model's pipeline run was measured. */
+  runDate: string;
 }
 
 export interface BenchmarkResults {
   benchmark: string;
-  /** ISO date of the eval run. */
-  runDate: string;
-  questionsPerModel: number;
   /** Why the $ figures are estimates, not measured spend. Surface wherever cost is charted. */
   pricingNote: string;
   source: string;
@@ -58,6 +57,20 @@ export function pricingSnapshotDates(results: BenchmarkResults): string[] {
   const dates = new Set<string>();
   for (const model of results.models) if (model.pricing) dates.add(model.pricing.pricedAt);
   return [...dates].sort();
+}
+
+/** Unique measurement dates across models, oldest first (for page copy). */
+export function runDates(results: BenchmarkResults): string[] {
+  const dates = new Set<string>();
+  for (const model of results.models) dates.add(model.runDate);
+  return [...dates].sort();
+}
+
+/** Unique per-model story sample sizes, ascending (for page copy). */
+export function storySampleSizes(results: BenchmarkResults): number[] {
+  const sizes = new Set<number>();
+  for (const model of results.models) sizes.add(model.stories);
+  return [...sizes].sort((a, b) => a - b);
 }
 
 export const benchmark = raw as BenchmarkResults;
@@ -74,7 +87,3 @@ export function costUsdPerStory(model: BenchmarkModel): number | undefined {
   return runCost / model.stories;
 }
 
-/** Total tokens consumed per Story. */
-export function tokensPerStory(model: BenchmarkModel): number {
-  return model.stories ? (model.promptTokens + model.completionTokens) / model.stories : 0;
-}

--- a/noah-portfolio/lib/benchmark/data.ts
+++ b/noah-portfolio/lib/benchmark/data.ts
@@ -1,0 +1,80 @@
+import raw from "./results.json";
+
+export type ModelVerdict = "default" | "finalist" | "eliminated" | "candidate";
+
+export interface ModelPricing {
+  /** USD per single prompt token (OpenRouter units). */
+  promptUsdPerTok: number;
+  /** USD per single completion token (OpenRouter units). */
+  completionUsdPerTok: number;
+  /** ISO date this model's OpenRouter pricing snapshot was taken. */
+  pricedAt: string;
+}
+
+export interface BenchmarkModel {
+  /** OpenRouter slug, e.g. "z-ai/glm-5.2". */
+  id: string;
+  /** Human display name. */
+  label: string;
+  /** Stories attempted for this model (denominator for plan rates). */
+  stories: number;
+  /** Fraction of Stories whose plan validated on attempt 1 (0–1). */
+  planFirstTryValid: number;
+  /** Fraction of Stories whose plan validated after repair (0–1). */
+  planFinalValid: number;
+  /** Fraction of scene cases that validated (0–1). */
+  scenesValid: number;
+  /** Worst cross-scene body-token Jaccard similarity; lower is better. */
+  repetitionMax: number;
+  /** Mean cross-scene body-token Jaccard similarity; lower is better. */
+  repetitionMean: number;
+  /** Banned filler-phrase occurrences across all scene bodies. */
+  bannedPhrases: number;
+  /** Mean wall-clock milliseconds per Story. */
+  meanStoryMs: number;
+  /** Prompt tokens across the whole run (all stories). */
+  promptTokens: number;
+  /** Completion tokens across the whole run (all stories). */
+  completionTokens: number;
+  /** OpenRouter pricing snapshot; absent for local/free models. */
+  pricing?: ModelPricing;
+  verdict: ModelVerdict;
+  note: string;
+}
+
+export interface BenchmarkResults {
+  benchmark: string;
+  /** ISO date of the eval run. */
+  runDate: string;
+  questionsPerModel: number;
+  /** Why the $ figures are estimates, not measured spend. Surface wherever cost is charted. */
+  pricingNote: string;
+  source: string;
+  models: BenchmarkModel[];
+}
+
+/** Unique pricing-snapshot dates across models, oldest first (for chart footnotes). */
+export function pricingSnapshotDates(results: BenchmarkResults): string[] {
+  const dates = new Set<string>();
+  for (const model of results.models) if (model.pricing) dates.add(model.pricing.pricedAt);
+  return [...dates].sort();
+}
+
+export const benchmark = raw as BenchmarkResults;
+
+/**
+ * Estimated USD per Story: run token totals × the pricing snapshot, over
+ * stories attempted. An estimate — see {@link BenchmarkResults.pricingNote}.
+ */
+export function costUsdPerStory(model: BenchmarkModel): number | undefined {
+  if (!model.pricing || !model.stories) return undefined;
+  const runCost =
+    model.promptTokens * model.pricing.promptUsdPerTok +
+    model.completionTokens * model.pricing.completionUsdPerTok;
+  return runCost / model.stories;
+}
+
+/** Total tokens consumed per Story. */
+export function tokensPerStory(model: BenchmarkModel): number {
+  return model.stories ? (model.promptTokens + model.completionTokens) / model.stories : 0;
+}

--- a/noah-portfolio/lib/benchmark/results.json
+++ b/noah-portfolio/lib/benchmark/results.json
@@ -1,0 +1,156 @@
+{
+  "benchmark": "story-pipeline",
+  "runDate": "2026-07-18",
+  "questionsPerModel": 5,
+  "pricingNote": "Costs are estimates: run token totals \u00d7 one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary materially (GLM-5.2 endpoints ranged $0.2968/$0.9328 to $1.05/$4.40 per MTok at review time).",
+  "source": "scripts/story-model-eval.ts --pipeline",
+  "models": [
+    {
+      "id": "z-ai/glm-5.2",
+      "label": "GLM 5.2",
+      "stories": 5,
+      "planFirstTryValid": 0.8,
+      "planFinalValid": 1,
+      "scenesValid": 1,
+      "repetitionMax": 0.039,
+      "repetitionMean": 0.012,
+      "bannedPhrases": 0,
+      "meanStoryMs": 38930,
+      "promptTokens": 57631,
+      "completionTokens": 28190,
+      "pricing": {
+        "promptUsdPerTok": 2.94e-07,
+        "completionUsdPerTok": 9.24e-07,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "default",
+      "note": "Blinded-review winner (C > A > B): best breadth, zero entailment violations, MIT license. Promoted to the application default."
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "label": "DeepSeek V4 Flash",
+      "stories": 5,
+      "planFirstTryValid": 1,
+      "planFinalValid": 1,
+      "scenesValid": 1,
+      "repetitionMax": 0.163,
+      "repetitionMean": 0.065,
+      "bannedPhrases": 0,
+      "meanStoryMs": 67887,
+      "promptTokens": 45334,
+      "completionTokens": 31247,
+      "pricing": {
+        "promptUsdPerTok": 9.8e-08,
+        "completionUsdPerTok": 1.96e-07,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "finalist",
+      "note": "The former default. Perfect validity but the highest cross-scene repetition (0.163 max Jaccard) and 68 s per Story."
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "label": "GPT-OSS 120B",
+      "stories": 5,
+      "planFirstTryValid": 0.6,
+      "planFinalValid": 1,
+      "scenesValid": 1,
+      "repetitionMax": 0.144,
+      "repetitionMean": 0.069,
+      "bannedPhrases": 1,
+      "meanStoryMs": 8298,
+      "promptTokens": 64975,
+      "completionTokens": 23272,
+      "pricing": {
+        "promptUsdPerTok": 3.7e-08,
+        "completionUsdPerTok": 1.7e-07,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "finalist",
+      "note": "Fastest and cheapest by far (8.3 s/Story), but shipped one banned filler phrase and invented an evidence relationship in the blinded review."
+    },
+    {
+      "id": "qwen/qwen3.5-27b",
+      "label": "Qwen3.5 27B",
+      "stories": 5,
+      "planFirstTryValid": 0.6,
+      "planFinalValid": 1,
+      "scenesValid": 1,
+      "repetitionMax": 0,
+      "repetitionMean": 0,
+      "bannedPhrases": 0,
+      "meanStoryMs": 185908,
+      "promptTokens": 47026,
+      "completionTokens": 55949,
+      "pricing": {
+        "promptUsdPerTok": 2.6e-07,
+        "completionUsdPerTok": 2.6e-06,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "eliminated",
+      "note": "Zero repetition but 186 s per Story and the highest completion-token bill of the field."
+    },
+    {
+      "id": "mistralai/mistral-small-2603",
+      "label": "Mistral Small 2603",
+      "stories": 5,
+      "planFirstTryValid": 0.2,
+      "planFinalValid": 0.8,
+      "scenesValid": 1,
+      "repetitionMax": 0.122,
+      "repetitionMean": 0.033,
+      "bannedPhrases": 0,
+      "meanStoryMs": 10963,
+      "promptTokens": 71569,
+      "completionTokens": 7088,
+      "pricing": {
+        "promptUsdPerTok": 1.5e-07,
+        "completionUsdPerTok": 6e-07,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "eliminated",
+      "note": "Fast, but only 1 in 5 plans was valid on the first try and one Story never validated even after repair."
+    },
+    {
+      "id": "z-ai/glm-4.7-flash",
+      "label": "GLM 4.7 Flash",
+      "stories": 5,
+      "planFirstTryValid": 0.2,
+      "planFinalValid": 0.8,
+      "scenesValid": 0.93,
+      "repetitionMax": 0.137,
+      "repetitionMean": 0.035,
+      "bannedPhrases": 0,
+      "meanStoryMs": 231562,
+      "promptTokens": 62423,
+      "completionTokens": 51287,
+      "pricing": {
+        "promptUsdPerTok": 6.05e-08,
+        "completionUsdPerTok": 4e-07,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "eliminated",
+      "note": "232 s per Story with 20% first-try plan validity \u2014 slow and unreliable."
+    },
+    {
+      "id": "qwen/qwen3.5-35b-a3b",
+      "label": "Qwen3.5 35B A3B",
+      "stories": 5,
+      "planFirstTryValid": 0,
+      "planFinalValid": 0.2,
+      "scenesValid": 0.67,
+      "repetitionMax": 0.017,
+      "repetitionMean": 0.006,
+      "bannedPhrases": 0,
+      "meanStoryMs": 296394,
+      "promptTokens": 13405,
+      "completionTokens": 27592,
+      "pricing": {
+        "promptUsdPerTok": 1.4e-07,
+        "completionUsdPerTok": 1e-06,
+        "pricedAt": "2026-07-18"
+      },
+      "verdict": "eliminated",
+      "note": "No plan ever validated first try; only one Story survived repair. 296 s per Story."
+    }
+  ]
+}

--- a/noah-portfolio/lib/benchmark/results.json
+++ b/noah-portfolio/lib/benchmark/results.json
@@ -1,7 +1,5 @@
 {
   "benchmark": "story-pipeline",
-  "runDate": "2026-07-18",
-  "questionsPerModel": 5,
   "pricingNote": "Costs are estimates: run token totals \u00d7 one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary materially (GLM-5.2 endpoints ranged $0.2968/$0.9328 to $1.05/$4.40 per MTok at review time).",
   "source": "scripts/story-model-eval.ts --pipeline",
   "models": [
@@ -24,7 +22,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "default",
-      "note": "Blinded-review winner (C > A > B): best breadth, zero entailment violations, MIT license. Promoted to the application default."
+      "note": "Blinded-review winner (C > A > B): best breadth, zero entailment violations, MIT license. Promoted to the application default.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -45,7 +44,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "finalist",
-      "note": "The former default. Perfect validity but the highest cross-scene repetition (0.163 max Jaccard) and 68 s per Story."
+      "note": "The former default. Perfect validity but the highest cross-scene repetition (0.163 max Jaccard) and 68 s per Story.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -66,7 +66,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "finalist",
-      "note": "Fastest and cheapest by far (8.3 s/Story), but shipped one banned filler phrase and invented an evidence relationship in the blinded review."
+      "note": "Fastest and cheapest by far (8.3 s/Story), but shipped one banned filler phrase and invented an evidence relationship in the blinded review.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "qwen/qwen3.5-27b",
@@ -87,7 +88,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
-      "note": "Zero repetition but 186 s per Story and the highest completion-token bill of the field."
+      "note": "Zero repetition but 186 s per Story and the highest completion-token bill of the field.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "mistralai/mistral-small-2603",
@@ -108,7 +110,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
-      "note": "Fast, but only 1 in 5 plans was valid on the first try and one Story never validated even after repair."
+      "note": "Fast, but only 1 in 5 plans was valid on the first try and one Story never validated even after repair.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "z-ai/glm-4.7-flash",
@@ -129,7 +132,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
-      "note": "232 s per Story with 20% first-try plan validity \u2014 slow and unreliable."
+      "note": "232 s per Story with 20% first-try plan validity \u2014 slow and unreliable.",
+      "runDate": "2026-07-18"
     },
     {
       "id": "qwen/qwen3.5-35b-a3b",
@@ -150,7 +154,8 @@
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
-      "note": "No plan ever validated first try; only one Story survived repair. 296 s per Story."
+      "note": "No plan ever validated first try; only one Story survived repair. 296 s per Story.",
+      "runDate": "2026-07-18"
     }
   ]
 }

--- a/noah-portfolio/lib/env.ts
+++ b/noah-portfolio/lib/env.ts
@@ -7,6 +7,7 @@ export interface CloudflareD1Config {
 export interface OpenRouterEnv {
   openrouterApiKey: string;
   openrouterModel: string;
+  openrouterProviderOrder: string[] | undefined;
 }
 
 export interface LangfuseEnv {
@@ -19,12 +20,21 @@ export function getServerEnv(): OpenRouterEnv {
   const openrouterApiKey = process.env.OPENROUTER_API_KEY;
   if (!openrouterApiKey) throw new Error("Missing OPENROUTER_API_KEY");
 
+  const providerOrderValue = process.env.OPENROUTER_PROVIDER_ORDER;
+  const providerOrder =
+    providerOrderValue === undefined
+      ? undefined
+      : providerOrderValue.split(",").map((provider) => provider.trim());
+  if (providerOrder?.some((provider) => !provider)) {
+    throw new Error("OPENROUTER_PROVIDER_ORDER must not contain empty entries");
+  }
+
   return {
     openrouterApiKey,
-    openrouterModel: process.env.OPENROUTER_MODEL || "deepseek/deepseek-v4-flash",
+    openrouterModel: process.env.OPENROUTER_MODEL || "z-ai/glm-5.2",
+    openrouterProviderOrder: providerOrder,
   };
 }
-
 
 /** D1-only environment access for strongly consistent Story publication. */
 export function getD1Env(): CloudflareD1Config | undefined {

--- a/noah-portfolio/lib/hooks/__tests__/usePortfolioCanvas.test.tsx
+++ b/noah-portfolio/lib/hooks/__tests__/usePortfolioCanvas.test.tsx
@@ -25,6 +25,7 @@ const SECOND_PUBLICATION_TOKEN = `${SECOND_STORY_ID}.${"B".repeat(43)}`;
 function makePlan(question = "What has Noah built?"): StoryPlan {
   return {
     question,
+    mode: "grounded",
     backdropPreset: "ditherIndigo",
     relatedQuestions: [
       "Which systems has Noah designed?",

--- a/noah-portfolio/lib/jsonui/__tests__/homeSpec.render.test.tsx
+++ b/noah-portfolio/lib/jsonui/__tests__/homeSpec.render.test.tsx
@@ -248,10 +248,11 @@ describe("homeSpec end-to-end render", () => {
       "LLM Comparison app",
       "Moodify",
       "Ask-Me Portfolio",
+      "Story Model Benchmark",
     ]) {
       expect(screen.getByRole("heading", { name: project })).toBeInTheDocument();
     }
-    expect(buildsQueries.getAllByRole("link")).toHaveLength(4);
+    expect(buildsQueries.getAllByRole("link")).toHaveLength(5);
 
     for (const operatingSystem of ["Debian", "Ubuntu", "Windows", "WSL2", "macOS"]) {
       expect(operatingSystemQueries.getByAltText(operatingSystem)).toBeInTheDocument();

--- a/noah-portfolio/lib/llm/__tests__/prompt.test.ts
+++ b/noah-portfolio/lib/llm/__tests__/prompt.test.ts
@@ -10,8 +10,8 @@ import {
   CORPUS_PROJECT_PROMPT_CATALOG,
 } from "@/lib/story/evidence";
 import {
-  FIVE_SCENE_PROJECT_USAGE_EXAMPLE,
-  THREE_SCENE_PROJECT_USAGE_EXAMPLE,
+  GOLD_STANDARD_STORY_PLAN_EXAMPLE,
+  SCENE_COMPOSITION_EXAMPLE,
 } from "@/lib/llm/examples";
 import {
   PROJECT_SLUGS,
@@ -19,6 +19,7 @@ import {
   STORY_REGISTERS,
   type ScenePlan,
 } from "@/lib/story/types";
+import { assertValidStoryPlan } from "@/lib/story/validation";
 import {
   buildSceneRepairMessage,
   buildSceneSystemPrompt,
@@ -39,6 +40,16 @@ const lockedScene: ScenePlan = {
   projectSlugs: ["ask-me-portfolio"],
   cue: { phase: "intro", focus: "center", intensity: "strong" },
 };
+
+const visitorQuestion = "How does Noah turn complex systems into products?";
+const storyOutline = [
+  {
+    index: lockedScene.index,
+    role: lockedScene.role,
+    title: lockedScene.title,
+    claim: lockedScene.claim,
+  },
+] as const;
 
 describe("Story generation prompts", () => {
   it("derives every model-visible Motion Asset choice from the reviewed catalog", () => {
@@ -68,11 +79,13 @@ describe("Story generation prompts", () => {
       expect(prompt).toContain(ref.path);
       expect(prompt).toContain(ref.excerpt);
     }
-    expect(prompt).toMatch(/Every factual claim must be supported/i);
+    expect(prompt).toMatch(/Every factual clause in every claim or body sentence must be directly entailed/i);
+    expect(prompt).toMatch(/cite only Refs the scene actually uses/i);
+    expect(prompt).toMatch(/list of tool names does not establish how Noah used each tool/i);
     expect(prompt).toMatch(/never create an Evidence Ref/i);
   });
 
-  it("allows only real Corpus project slugs and demonstrates relevant usage", () => {
+  it("allows only real Corpus project slugs and includes one valid gold-standard Plan", () => {
     const prompt = buildSystemPrompt();
 
     for (const project of CORPUS_PROJECT_PROMPT_CATALOG) {
@@ -83,25 +96,67 @@ describe("Story generation prompts", () => {
     expect(prompt).toMatch(/attach 1–3 relevant \"projectSlugs\" to evidence or synthesis scenes/i);
     expect(prompt).toMatch(/Never invent a project slug/i);
     expect(prompt).toMatch(/trusted application code supplies project URLs, images, technologies/i);
-    expect(THREE_SCENE_PROJECT_USAGE_EXAMPLE).toHaveLength(3);
-    expect(FIVE_SCENE_PROJECT_USAGE_EXAMPLE).toHaveLength(5);
-    expect(prompt).toContain(JSON.stringify(THREE_SCENE_PROJECT_USAGE_EXAMPLE, null, 2));
-    expect(prompt).toContain(JSON.stringify(FIVE_SCENE_PROJECT_USAGE_EXAMPLE, null, 2));
+    expect(prompt).toContain(JSON.stringify(GOLD_STANDARD_STORY_PLAN_EXAMPLE, null, 2));
+    expect(() =>
+      assertValidStoryPlan(
+        GOLD_STANDARD_STORY_PLAN_EXAMPLE,
+        CORPUS_EVIDENCE_REFS,
+        GOLD_STANDARD_STORY_PLAN_EXAMPLE.question,
+      )
+    ).not.toThrow();
   });
 
-  it("requires a locked 3–5 Scene Plan before composition", () => {
+  it("requires a locked variable-length Scene Plan before composition", () => {
     const prompt = buildSystemPrompt();
 
     expect(prompt).toMatch(/complete Story Plan before any scene body/i);
     expect(prompt).toContain('"question": "the visitor question exactly as supplied"');
-    expect(prompt).toMatch(/Copy the visitor question exactly/i);
-    expect(prompt).toMatch(/Produce 3–5 scenes/i);
-    expect(prompt).toMatch(/Scene 1 has role "direct-answer"/i);
-    expect(prompt).toMatch(/final scene has role "synthesis"/i);
+    expect(prompt).toContain('"mode": "grounded | boundary"');
+    expect(prompt).toMatch(/Set "mode" to "grounded".+Use "boundary" only when the catalogs genuinely cannot ground/i);
+    expect(prompt).toMatch(/Choose 1–5 scenes/i);
+    expect(prompt).toMatch(/Mode "boundary" requires exactly 1 scene/i);
+    expect(prompt).toMatch(/Thin grounded evidence with one fact cluster requires 1–2 scenes/i);
+    expect(prompt).toMatch(/Use 3–5 scenes only when.+disjoint grounded fact sets/i);
+    expect(prompt).toMatch(/For n=1.+role "direct-answer".+cue phase "intro"/i);
+    expect(prompt).toContain('For n=2, use roles ["direct-answer", "synthesis"] and cue phases ["intro", "resolve"]');
+    expect(prompt).toMatch(/For n>=3.+first scene.+direct-answer.+middle scene.+evidence.+final scene.+synthesis/i);
     expect(prompt).toMatch(/distinct eligible Scene Pattern/i);
-    expect(prompt).toMatch(/at least two Registers/i);
-    expect(prompt).toMatch(/middle evidence Scene must cite two or more Evidence Ref IDs/i);
+    expect(prompt).toMatch(/at least two Registers when n>=2/i);
+    expect(prompt).toMatch(/When middle evidence Scenes exist, at least one must cite two or more Evidence Ref IDs/i);
+    expect(prompt).toMatch(/Mode "grounded" requires one or more existing Evidence Ref IDs on every scene, including n=1/i);
     expect(prompt).toMatch(/2–3 unique/i);
+    expect(prompt).toMatch(/Never pad/i);
+    expect(prompt).toMatch(/specific noun-phrase title/i);
+    expect(prompt).toMatch(/concrete, checkable fact/i);
+    expect(prompt).toMatch(/real subject overlap with the asset description or semanticTags/i);
+    expect(prompt).toMatch(/timeline" only for dated progression/i);
+    expect(prompt).toMatch(/system-diagram" only for an architecture explicitly present/i);
+    expect(prompt).toMatch(/printer-forge or print-layers as metaphors for software/i);
+    expect(prompt).toMatch(/morning-coffee merely because a scene is the closer/i);
+    expect(prompt).toMatch(/without upgrading them into generic impact claims/i);
+    expect(prompt).toMatch(/disjoint primary fact sets that no two scenes share/i);
+    expect(prompt).toMatch(/direct-answer claim cannot bundle facts reserved for later scenes/i);
+    expect(prompt).toMatch(/Keep one grounded fact cluster in 1 scene/i);
+    expect(prompt).toMatch(/3D-printing question is one overlapping fact cluster grounded by career-3 and fun-fact-1/i);
+    expect(prompt).toMatch(/range or breadth questions, prefer covering more distinct relevant projects/i);
+    expect(prompt).toMatch(/cover at least 3 projects when the catalog provides them/i);
+    expect(prompt).toMatch(/never assert a relationship between facts/i);
+    expect(prompt).toMatch(/Co-occurrence.+is not a relationship/i);
+    expect(prompt).toMatch(/Every qualifier and adjective must come from the excerpt/i);
+    expect(prompt).toMatch(/excerpt gives a list, present it only as a list/i);
+    expect(prompt).toMatch(/project description establishes what the project does, not Noah's role/i);
+    expect(prompt).toMatch(/use any excerpt as negative proof/i);
+    expect(prompt).toMatch(/boundary claim is a standalone unattributed absence sentence/i);
+    expect(prompt).toContain('A mode "boundary" Plan has exactly one direct-answer scene and must use "evidenceRefIds": []');
+    expect(prompt).toMatch(/never describe what those Refs omit/i);
+    expect(prompt).toMatch(/mode "boundary" Plan has exactly one direct-answer scene/i);
+    expect(prompt).toMatch(/Put redirects only in relatedQuestions/i);
+    expect(prompt).toMatch(/mentally identify at least one Evidence Ref ID/i);
+    expect(prompt).toMatch(/corpus cannot ground|catalogs cannot ground/i);
+    expect(prompt).toMatch(/specific and directly answerable from the catalogs/i);
+    expect(prompt).toMatch(/all Scene Patterns are pairwise distinct/i);
+    expect(prompt).toMatch(/projectSlugs is either absent or contains 1–3 exact catalog slugs/i);
+    expect(prompt).toMatch(/question is copied exactly/i);
 
     for (const pattern of SCENE_PATTERNS) expect(prompt).toContain(pattern);
     for (const register of STORY_REGISTERS) expect(prompt).toContain(register);
@@ -110,7 +165,7 @@ describe("Story generation prompts", () => {
 
   it("constrains composition and repair to the locked claim, asset, order, and Evidence Refs", () => {
     const evidence = [CORPUS_EVIDENCE_REFS[0]];
-    const prompt = buildSceneSystemPrompt(lockedScene, evidence);
+    const prompt = buildSceneSystemPrompt(visitorQuestion, storyOutline, lockedScene, evidence);
     const repair = buildSceneRepairMessage('{"body":""}', "Body is required");
 
     expect(prompt).toContain(JSON.stringify(lockedScene.assetId));
@@ -118,7 +173,48 @@ describe("Story generation prompts", () => {
     expect(prompt).toContain(JSON.stringify(lockedScene.evidenceRefIds[0]));
     expect(prompt).toContain(JSON.stringify(lockedScene.projectSlugs?.[0]));
     expect(prompt).toContain(evidence[0].excerpt);
-    expect(prompt).toContain('{"body":"one or two concise sentences"}');
+    expect(prompt).toContain('{"body":"one to four specific sentences"}');
+    expect(prompt).toContain(JSON.stringify(visitorQuestion));
+    expect(prompt).toContain(JSON.stringify(storyOutline, null, 2));
+    expect(prompt).toContain(SCENE_COMPOSITION_EXAMPLE.body);
+    expect(prompt).toMatch(/1–4 sentences in Noah's first-person voice/i);
+    expect(prompt).toMatch(/Target 300–700 characters/i);
+    expect(prompt).toMatch(/hard schema cap is 1200 characters/i);
+    expect(prompt).toMatch(/one concise grounded restatement of this scene's own claim fact is allowed/i);
+    expect(prompt).toMatch(/Outside the own-fact and short-transition exceptions/i);
+    expect(prompt).toMatch(/no other scene's facts beyond a short transition/i);
+    expect(prompt).toMatch(/Story Outline as a fact-ownership map/i);
+    expect(prompt).toMatch(/other scenes may appear only as a short transitional clause/i);
+    expect(prompt).toMatch(/new information must come from this scene's assigned locked Evidence/i);
+    expect(prompt).toMatch(/synthesis cannot inventory, paraphrase, or relabel earlier facts/i);
+    expect(prompt).toMatch(/honest-boundary mode, write only standalone unattributed absence sentences/i);
+    expect(prompt).toMatch(/boundary scene must not mention or summarize its locked Evidence/i);
+    expect(prompt).toMatch(/Do not say the listed items are "relied on"/i);
+    expect(prompt).toMatch(/otherwise say "my portfolio includes X" or "the X project does Y"/i);
+    for (const filler of [
+      "technical depth",
+      "clear product story",
+      "passionate",
+      "seamless",
+      "leveraging",
+      "showcase",
+      "aligning",
+      "robust",
+      "cutting-edge",
+      "The bigger picture",
+      "Impact",
+      "Synthesis of Skills",
+      "Why This Stack Matters",
+      "Making Things That Matter",
+      "shows the kind of work I do",
+      "ability to work across",
+      "core part of my identity",
+      "bridging prototyping with production",
+      "Current Role",
+      "Full-Stack Range",
+    ]) {
+      expect(prompt).toContain(`"${filler}"`);
+    }
     expect(prompt).toMatch(/cannot change any locked Plan field/i);
     expect(repair).toContain("Body is required");
     expect(repair).toMatch(/locked Scene Plan and Evidence Refs remain unchanged/i);
@@ -134,7 +230,11 @@ describe("Story generation prompts", () => {
   });
 
   it("contains no retired generated-answer vocabulary", () => {
-    const modelVisible = [buildSystemPrompt(), buildUserMessage("Tell me about Noah"), buildSceneSystemPrompt(lockedScene, [CORPUS_EVIDENCE_REFS[0]])].join("\n");
+    const modelVisible = [
+      buildSystemPrompt(),
+      buildUserMessage("Tell me about Noah"),
+      buildSceneSystemPrompt(visitorQuestion, storyOutline, lockedScene, [CORPUS_EVIDENCE_REFS[0]]),
+    ].join("\n");
 
     expect(modelVisible).not.toMatch(/StaticComposition|static mode|json-render|RFC\s*6902|JSON Patch|ProjectShowcase|StatReveal|NarrativeBeat/iu);
   });

--- a/noah-portfolio/lib/llm/examples.ts
+++ b/noah-portfolio/lib/llm/examples.ts
@@ -1,46 +1,66 @@
-export const THREE_SCENE_PROJECT_USAGE_EXAMPLE = [
-  { index: 0, role: "direct-answer" },
-  { index: 1, role: "evidence", projectSlugs: ["ask-me-portfolio", "moodify"] },
-  { index: 2, role: "synthesis", projectSlugs: ["ask-me-portfolio"] },
-] as const;
+export const GOLD_STANDARD_STORY_PLAN_EXAMPLE = {
+  question: "What did Noah build at Supa?",
+  mode: "grounded",
+  backdropPreset: "ditherTide",
+  scenes: [
+    {
+      id: "supa-training-data",
+      index: 0,
+      role: "direct-answer",
+      pattern: "hero-statement",
+      register: "editorial",
+      title: "Supa training-data tools, 2020–2025",
+      claim:
+        "From 2020 to 2025, I built data-labeling and AI training-data tooling end to end.",
+      assetId: "circuit-mind",
+      evidenceRefIds: ["career-2"],
+      cue: { phase: "intro", focus: "center", intensity: "strong" },
+    },
+    {
+      id: "supa-llm-evaluation",
+      index: 1,
+      role: "evidence",
+      pattern: "capability-map",
+      register: "technical",
+      title: "LLM evaluation tooling at Supa",
+      claim: "At Supa, I shipped the open-source LLM Comparison app as LLM evaluation tooling.",
+      assetId: "circuit-mind",
+      evidenceRefIds: ["career-2", "project-llm-comparison"],
+      projectSlugs: ["llm-comparison"],
+      cue: { phase: "develop", focus: "left", intensity: "strong" },
+    },
+    {
+      id: "supa-two-llm-comparison",
+      index: 2,
+      role: "synthesis",
+      pattern: "closing-synthesis",
+      register: "reflective",
+      title: "Two-LLM comparison",
+      claim:
+        "The open-source LLM Comparison app lets users pit two LLMs against each other and compare them.",
+      assetId: "morning-coffee",
+      evidenceRefIds: ["project-llm-comparison"],
+      projectSlugs: ["llm-comparison"],
+      cue: { phase: "resolve", focus: "right", intensity: "medium" },
+    },
+  ],
+  relatedQuestions: [
+    "How did Noah evaluate LLMs at Supa?",
+    "Which Noah project lets users compare two LLMs?",
+    "What AI engineering work did Noah do after Supa?",
+  ],
+} as const;
 
-export const FIVE_SCENE_PROJECT_USAGE_EXAMPLE = [
-  { index: 0, role: "direct-answer" },
-  { index: 1, role: "evidence", projectSlugs: ["ai-image-cutout"] },
-  { index: 2, role: "evidence", projectSlugs: ["llm-comparison"] },
-  { index: 3, role: "evidence", projectSlugs: ["ask-me-portfolio", "moodify"] },
-  {
-    index: 4,
-    role: "synthesis",
-    projectSlugs: ["ai-image-cutout", "llm-comparison", "ask-me-portfolio"],
-  },
-] as const;
+export const SCENE_COMPOSITION_EXAMPLE = {
+  body:
+    "Moodify lets people search for a favourite tune and watch the album cover's colour palette take over the page. The same palette trick recolours this site's hero dither.",
+} as const;
 
 export const STORY_EXAMPLES = `
-## Planning examples
+## Gold-standard complete Story Plan
 
-A valid plan has 3–5 ordered scenes. Scene 1 is the direct answer, one or more middle
-scenes carry evidence, and the final scene synthesizes a useful answer. Every scene
-locks one claim, one distinct eligible Scene Pattern, one Register, one Motion Asset ID,
-and one or more Evidence Ref IDs. The story uses at least two Registers and ends with
-2–3 grounded related questions.
+This example is complete and follows every invariant, including distinct Patterns, exact
+Evidence Ref IDs and project slugs, specific titles and claims, and answerable related questions:
 
-These are project-selection excerpts, not complete Plans. They demonstrate that projectSlugs
-are optional, use only exact catalog slugs, and belong on relevant evidence and synthesis scenes.
-
-Three-scene project usage:
-${JSON.stringify(THREE_SCENE_PROJECT_USAGE_EXAMPLE, null, 2)}
-
-Five-scene project usage:
-${JSON.stringify(FIVE_SCENE_PROJECT_USAGE_EXAMPLE, null, 2)}
-
-## Composition example
-
-For a locked scene, return only a JSON object with a concise body:
-
-{"body":"I build the interface and the systems behind it, so the work stays coherent from interaction through delivery."}
-
-The body supports the locked claim using only its locked Evidence Refs. It never changes
-scene identity, order, role, Pattern, Register, title, claim, Motion Asset, Evidence Refs,
-project slugs, or Scene Cue.
+${JSON.stringify(GOLD_STANDARD_STORY_PLAN_EXAMPLE, null, 2)}
 `;

--- a/noah-portfolio/lib/llm/openrouter.ts
+++ b/noah-portfolio/lib/llm/openrouter.ts
@@ -2,13 +2,15 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { getServerEnv } from "@/lib/env";
 
 /**
- * Build the OpenRouter chat model to use for spec generation.
+ * Build the model for Story generation.
  *
- * `getServerEnv()` is called lazily (inside this function, not at module
- * scope) so importing this module never throws when `OPENROUTER_API_KEY`
- * is unset — only calling `getModel()` does.
+ * Environment is read lazily inside this function, so importing this module
+ * never throws when provider credentials are unset.
  */
 export function getModel() {
   const env = getServerEnv();
-  return createOpenRouter({ apiKey: env.openrouterApiKey })(env.openrouterModel);
+  const openrouter = createOpenRouter({ apiKey: env.openrouterApiKey });
+  return env.openrouterProviderOrder
+    ? openrouter(env.openrouterModel, { provider: { order: env.openrouterProviderOrder } })
+    : openrouter(env.openrouterModel);
 }

--- a/noah-portfolio/lib/llm/prompt.ts
+++ b/noah-portfolio/lib/llm/prompt.ts
@@ -11,10 +11,11 @@ import {
   type EvidenceRef,
   type ScenePlan,
 } from "@/lib/story/types";
-import { STORY_EXAMPLES } from "@/lib/llm/examples";
+import { SCENE_COMPOSITION_EXAMPLE, STORY_EXAMPLES } from "@/lib/llm/examples";
 
 const PLAN_SCHEMA = `{
   "question": "the visitor question exactly as supplied",
+  "mode": "grounded | boundary",
   "backdropPreset": "one allowed backdrop preset",
   "scenes": [{
     "id": "scene-1",
@@ -22,10 +23,10 @@ const PLAN_SCHEMA = `{
     "role": "direct-answer | evidence | synthesis",
     "pattern": "one allowed Scene Pattern",
     "register": "one allowed Register",
-    "title": "short scene title",
-    "claim": "one concise factual claim",
+    "title": "specific noun phrase",
+    "claim": "concise cited fact, or a standalone unattributed absence for mode boundary",
     "assetId": "one allowed Motion Asset ID",
-    "evidenceRefIds": ["one or more Evidence Ref IDs"],
+    "evidenceRefIds": ["empty only for mode boundary; otherwise one or more Evidence Ref IDs"],
     "projectSlugs": ["optional: one to three real Corpus project slugs"],
     "cue": { "phase": "intro | develop | resolve", "focus": "center | left | right", "intensity": "quiet | medium | strong" }
   }],
@@ -40,8 +41,13 @@ Security and grounding rules:
 - Use only the Motion Asset IDs, Evidence Ref IDs, and project slugs in the catalogs below.
 - Never invent a project slug. The model selects slugs only; trusted application code supplies project URLs, images, technologies, and card content.
 - Never output markup, source code, URLs, import paths, renderer choices, animation parameters, or asset properties.
-- Every factual claim must be supported by all of its selected Evidence Refs.
-- Do not invent biography, employers, projects, outcomes, dates, technologies, or contact details.
+- Except for a standalone boundary absence answer, every factual clause in every claim or body sentence must be directly entailed by at least one cited Evidence excerpt; cite only Refs the scene actually uses.
+- A list of tool names does not establish how Noah used each tool, and a job description does not establish an outcome or impact. Unknown stays unknown.
+- Never assert a relationship between facts unless one cited excerpt states it. Co-occurrence—even in one excerpt—is not a relationship: "together", "both", "same", "blend", "balance", "supports", "demonstrates", "exemplifies", "reflects", "alongside", cause/effect, continuity, or one fact powering/enabling/driving another are forbidden unless the excerpt makes that link.
+- Every qualifier and adjective must come from the excerpt, keep its exact scope, and stay attached to the fact it qualifies. Never strengthen "keen" to "strong", "high-end" to "industrial", "into" to "hobby", or add "hands-on", "finished", "live", "interactive", or "side-by-side" when absent.
+- When an excerpt gives a list, present it only as a list. Do not say the listed items are "relied on", assign per-item uses, connect them to projects, or infer UI formats.
+- A project description establishes what the project does, not Noah's role in it. Say "I built", "I shipped", or "I created" only when a cited excerpt explicitly states that contribution; otherwise say "my portfolio includes X" or "the X project does Y".
+- Do not invent biography, employers, projects, outcomes, dates, technologies, usage details, or contact details.
 - Write concise first-person prose in Noah's voice.
 `;
 
@@ -59,18 +65,34 @@ ${PLAN_SCHEMA}
 
 Plan invariants:
 - Copy the visitor question exactly into "question"; never paraphrase or replace it.
-- Produce 3–5 scenes with indexes 0 through n-1 in exact array order and unique scene IDs.
-- Scene 1 has role "direct-answer", uses one of "${directPatterns}", and states the answer without suspense.
-- Every middle scene has role "evidence", adds only relevant supporting facts, and uses one of "${evidencePatterns}".
-- The final scene has role "synthesis", uses one of "${synthesisPatterns}", and gives a tailored takeaway.
-- Use a distinct eligible Scene Pattern for every scene and at least two Registers across the Story.
-- Select exactly one meaningful, allowlisted focal Motion Asset per scene.
-- Use one or more existing Evidence Ref IDs per scene; never create an Evidence Ref.
-- At least one middle evidence Scene must cite two or more Evidence Ref IDs.
+- Set "mode" to "grounded" whenever the catalogs can answer the question. Use "boundary" only when the catalogs genuinely cannot ground the requested answer.
+- Choose 1–5 scenes from the available grounded facts. Mode "boundary" requires exactly 1 scene with an honest absence answer. Thin grounded evidence with one fact cluster requires 1–2 scenes. Use 3–5 scenes only when the catalogs provide that many disjoint grounded fact sets. Fewer, denser scenes are better than padded scenes; never pad.
+- For n=1, the only scene has role "direct-answer", uses one of "${directPatterns}", has cue phase "intro", and states the answer without suspense.
+- For n=2, use roles ["direct-answer", "synthesis"] and cue phases ["intro", "resolve"] in that order. The direct-answer uses one of "${directPatterns}" and the synthesis uses one of "${synthesisPatterns}". The n=2 synthesis owns a distinct second grounded fact and must not repeat the direct-answer fact.
+- For n>=3, the first scene has role "direct-answer", every middle scene has role "evidence", and the final scene has role "synthesis". Use one of "${directPatterns}" for the direct answer, one of "${evidencePatterns}" for each evidence scene, and one of "${synthesisPatterns}" for the synthesis. Every direct-answer scene states the answer without suspense; the n>=3 synthesis connects named facts already established without upgrading them into generic impact claims.
+- Use a distinct eligible Scene Pattern for every scene. Use at least two Registers when n>=2; a single-scene Story may use one Register. Choose middle Patterns by content: "timeline" only for dated progression and "system-diagram" only for an architecture explicitly present in the evidence.
+- Give every scene a specific noun-phrase title naming its actual fact or tension. Ban generic deck headings including "The Evidence", "Direct Answer", "Synthesis", "Overview", "The bigger picture", "Impact", "Synthesis of Skills", "Why This Stack Matters", "Making Things That Matter", "Current Role", and "Full-Stack Range".
+- Except for an honest boundary statement, every claim must state at least one concrete, checkable fact drawn from its cited Evidence excerpts: an employer, project name, technology, timeframe, or outcome.
+- Assign each concrete proposition to exactly one scene before writing claims, creating disjoint primary fact sets that no two scenes share. The direct-answer claim cannot bundle facts reserved for later scenes; synthesis cannot repeat or relabel earlier propositions.
+- Keep one grounded fact cluster in 1 scene; use 2 only when the evidence supports two distinct, non-repeating angles. When excerpts overlap, assign each shared proposition to only one scene; another scene may state only a non-overlapping fact, and if none remains use 1 scene. The 3D-printing question is one overlapping fact cluster grounded by career-3 and fun-fact-1: use exactly 1 grounded scene citing both Refs, never a boundary answer, and never claim professional-to-personal continuity.
+- For range or breadth questions, prefer covering more distinct relevant projects over re-explaining fewer projects; cover at least 3 projects when the catalog provides them.
+- Select exactly one meaningful, allowlisted focal Motion Asset per scene, and ensure its eligibleScenePatterns includes the scene's Pattern. Require real subject overlap with the asset description or semanticTags. Never use printer-forge or print-layers as metaphors for software delivery or stack layers, and never select morning-coffee merely because a scene is the closer. If no asset matches, use the most neutral compatible asset rather than a misleading one.
+- Mode "boundary" uses an empty evidenceRefIds array. Mode "grounded" requires one or more existing Evidence Ref IDs on every scene, including n=1; never create an Evidence Ref.
+- When middle evidence Scenes exist, at least one must cite two or more Evidence Ref IDs.
 - When the question touches Noah's work or projects, attach 1–3 relevant "projectSlugs" to evidence or synthesis scenes. Omit the field when no project is relevant.
 - Never attach an invented slug, an empty projectSlugs array, or project card data.
-- Cue phase is "intro" for the first scene, "resolve" for the final scene, and "develop" otherwise.
-- Include 2–3 unique, nonempty related questions grounded in the catalogs.
+- Cue phases must be ["intro"] for n=1, ["intro", "resolve"] for n=2, and "intro" for the first scene, "resolve" for the final scene, and "develop" otherwise when n>=3.
+- Include 2–3 unique related questions that are specific and directly answerable from the catalogs. Before including each question, mentally identify at least one Evidence Ref ID that answers it.
+
+Grounding boundary:
+- If the catalogs cannot ground the visitor's question, do not fabricate, imply knowledge, use any excerpt as negative proof, or pad with unrelated achievements.
+- The boundary claim is a standalone unattributed absence sentence. Its grammatical subject cannot be the corpus, profile, excerpt, Evidence, or Ref; do not join coverage to absence with "but", "however", or "though", and never say a record "doesn't include", "doesn't mention", or "doesn't say" the answer.
+- A mode "boundary" Plan has exactly one direct-answer scene and must use "evidenceRefIds": []; an irrelevant Ref is not proof of absence, and the claim/body must not mention unrelated catalog content.
+- Put redirects only in relatedQuestions for mode "boundary", never in additional scenes.
+- In multi-scene mode "grounded" Stories, later scenes may describe only what cited Refs do cover; they never describe what those Refs omit or pretend covered topics answer the question.
+- For n>=3 mode "grounded" Stories, the synthesis connects grounded facts. For mode "boundary" Stories, relatedQuestions alone redirect to specific answerable topics.
+
+Before returning, verify: all Scene Patterns are pairwise distinct; every asset is eligible for its scene's Pattern; projectSlugs is either absent or contains 1–3 exact catalog slugs—never an empty array; and question is copied exactly.
 
 Allowed Scene Patterns: ${SCENE_PATTERNS.join(", ")}
 Allowed Registers: ${STORY_REGISTERS.join(", ")}
@@ -94,19 +116,50 @@ export function buildUserMessage(question: string): string {
 }
 
 /** Prompt for composing one scene without permitting changes to its locked Plan. */
-export function buildSceneSystemPrompt(scene: ScenePlan, evidence: readonly EvidenceRef[]): string {
+export function buildSceneSystemPrompt(
+  question: string,
+  storyOutline: readonly Pick<ScenePlan, "index" | "role" | "title" | "claim">[],
+  scene: ScenePlan,
+  evidence: readonly EvidenceRef[],
+): string {
+  const compactOutline = storyOutline.map(({ index, role, title, claim }) => ({
+    index,
+    role,
+    title,
+    claim,
+  }));
+
   return `${COMMON_RULES}
 Compose only the body for the locked scene below. Return exactly one JSON object of the shape
-{"body":"one or two concise sentences"}, with no other fields, fences, or commentary.
+{"body":"one to four specific sentences"}, with no other fields, fences, or commentary.
 
-The body must directly support the locked claim using only the locked Evidence Refs. Do not repeat
-the title. Do not add facts from other Evidence Refs. You cannot change any locked Plan field.
+Body rules:
+- Write 1–4 sentences in Noah's first-person voice. Target 300–700 characters only when the assigned evidence supports that length; the hard schema cap is 1200 characters.
+- Directly support the locked claim using only the locked Evidence Refs. Every factual clause must be entailed by an excerpt; plausible world knowledge is forbidden. Exception: a boundary scene must not mention or summarize its locked Evidence.
+- Except in a boundary scene, add a concrete specific from this scene's assigned fact when the claim has not already consumed it.
+- If the claim consumes the scene's only assigned fact, one concise grounded restatement of this scene's own claim fact is allowed. This is the only body-substance restatement exception; never pad with another scene's fact.
+- Treat the Story Outline as a fact-ownership map. Facts assigned to other scenes may appear only as a short transitional clause, never as this body's substance; this body's new information must come from this scene's assigned locked Evidence.
+- Outside the own-fact and short-transition exceptions, do not restate the locked title or claim, add facts from other Evidence Refs, or repeat another scene's proposition. A synthesis cannot inventory, paraphrase, or relabel earlier facts.
+- In honest-boundary mode, write only standalone unattributed absence sentences: never mention the corpus, profile, excerpt, Evidence, Ref, or any locked-excerpt content; never use "but", "however", "though", "doesn't include", "doesn't mention", or "doesn't say". Covered alternatives and redirects belong only in relatedQuestions.
+- Never use "technical depth", "clear product story", "passionate", "seamless", "leveraging", "showcase", "aligning", "robust", "cutting-edge", "The bigger picture", "Impact", "Synthesis of Skills", "Why This Stack Matters", "Making Things That Matter", "shows the kind of work I do", "ability to work across", "core part of my identity", "bridging prototyping with production", "Current Role", or "Full-Stack Range". Use plain, concrete language instead.
+- The banned phrases remain banned even if they appear in the locked claim or Story Outline.
+- Before returning, verify: 1–4 sentences; only excerpt-entailed clauses except for an honest boundary absence; no other scene's facts beyond a short transition; no title or claim copied verbatim outside the own-fact exception; and none of the banned phrases.
+- You cannot change any locked Plan field.
+
+# Visitor question
+${JSON.stringify(question)}
+
+# Compact Story Outline
+${JSON.stringify(compactOutline, null, 2)}
 
 # Locked Scene Plan
 ${JSON.stringify(scene, null, 2)}
 
 # Locked Evidence Refs
-${JSON.stringify(evidence, null, 2)}`;
+${JSON.stringify(evidence, null, 2)}
+
+# Composition example (style and specificity only; never copy a fact unless it appears in the Locked Evidence Refs)
+${JSON.stringify(SCENE_COMPOSITION_EXAMPLE)}`;
 }
 
 /** User message for the initial composition attempt. */

--- a/noah-portfolio/lib/llm/prompt.ts
+++ b/noah-portfolio/lib/llm/prompt.ts
@@ -13,6 +13,29 @@ import {
 } from "@/lib/story/types";
 import { SCENE_COMPOSITION_EXAMPLE, STORY_EXAMPLES } from "@/lib/llm/examples";
 
+export const BANNED_PHRASES = [
+  "technical depth",
+  "clear product story",
+  "passionate",
+  "seamless",
+  "leveraging",
+  "showcase",
+  "aligning",
+  "robust",
+  "cutting-edge",
+  "The bigger picture",
+  "Impact",
+  "Synthesis of Skills",
+  "Why This Stack Matters",
+  "Making Things That Matter",
+  "shows the kind of work I do",
+  "ability to work across",
+  "core part of my identity",
+  "bridging prototyping with production",
+  "Current Role",
+  "Full-Stack Range",
+] as const;
+
 const PLAN_SCHEMA = `{
   "question": "the visitor question exactly as supplied",
   "mode": "grounded | boundary",
@@ -141,7 +164,7 @@ Body rules:
 - Treat the Story Outline as a fact-ownership map. Facts assigned to other scenes may appear only as a short transitional clause, never as this body's substance; this body's new information must come from this scene's assigned locked Evidence.
 - Outside the own-fact and short-transition exceptions, do not restate the locked title or claim, add facts from other Evidence Refs, or repeat another scene's proposition. A synthesis cannot inventory, paraphrase, or relabel earlier facts.
 - In honest-boundary mode, write only standalone unattributed absence sentences: never mention the corpus, profile, excerpt, Evidence, Ref, or any locked-excerpt content; never use "but", "however", "though", "doesn't include", "doesn't mention", or "doesn't say". Covered alternatives and redirects belong only in relatedQuestions.
-- Never use "technical depth", "clear product story", "passionate", "seamless", "leveraging", "showcase", "aligning", "robust", "cutting-edge", "The bigger picture", "Impact", "Synthesis of Skills", "Why This Stack Matters", "Making Things That Matter", "shows the kind of work I do", "ability to work across", "core part of my identity", "bridging prototyping with production", "Current Role", or "Full-Stack Range". Use plain, concrete language instead.
+- Never use ${BANNED_PHRASES.map((phrase, index) => `${index === BANNED_PHRASES.length - 1 ? "or " : ""}"${phrase}"`).join(", ")}. Use plain, concrete language instead.
 - The banned phrases remain banned even if they appear in the locked claim or Story Outline.
 - Before returning, verify: 1–4 sentences; only excerpt-entailed clauses except for an honest boundary absence; no other scene's facts beyond a short transition; no title or claim copied verbatim outside the own-fact exception; and none of the banned phrases.
 - You cannot change any locked Plan field.

--- a/noah-portfolio/lib/story/__fixtures__/story-fixtures.ts
+++ b/noah-portfolio/lib/story/__fixtures__/story-fixtures.ts
@@ -5,6 +5,7 @@ import {
 import { seedStoryFixtures } from "@/lib/story/store";
 import {
   toPublicStory,
+  STORY_CONTRACT_VERSION,
   type ProjectSlug,
   type StoryProject,
   type StoryRecord,
@@ -85,7 +86,7 @@ function makeRecord({
   bodies,
   relatedQuestions,
   corpusRevision = "2026-07-14",
-  storyContractVersion = "v5",
+  storyContractVersion = STORY_CONTRACT_VERSION,
 }: {
   id: string;
   displayQuestion: string;
@@ -104,6 +105,7 @@ function makeRecord({
     createdAt: "2026-07-14T07:00:00.000Z",
     plan: {
       question: displayQuestion,
+      mode: "grounded",
       backdropPreset: "ditherTide",
       scenes: scenes.map((scene) => ({
         id: scene.id,

--- a/noah-portfolio/lib/story/__tests__/story.test.ts
+++ b/noah-portfolio/lib/story/__tests__/story.test.ts
@@ -51,6 +51,7 @@ const DEFAULT_QUESTION = "How does Noah approach complex products?";
 function makePlan(question = DEFAULT_QUESTION): StoryPlan {
   return {
     question,
+    mode: "grounded",
     backdropPreset: "ambientLava",
     scenes: [
       {
@@ -95,6 +96,27 @@ function makePlan(question = DEFAULT_QUESTION): StoryPlan {
     relatedQuestions: [
       "Which projects best show that approach?",
       "How does Noah work across product and engineering?",
+    ],
+  };
+}
+
+function makeSingleScenePlan(question = DEFAULT_QUESTION): StoryPlan {
+  const plan = makePlan(question);
+  return { ...plan, scenes: [plan.scenes[0]] };
+}
+
+function makeTwoScenePlan(question = DEFAULT_QUESTION): StoryPlan {
+  const plan = makePlan(question);
+  return {
+    ...plan,
+    scenes: [
+      plan.scenes[0],
+      {
+        ...plan.scenes[2],
+        id: "two-scene-synthesis",
+        index: 1,
+        evidenceRefIds: [evidence[2].id],
+      },
     ],
   };
 }
@@ -148,6 +170,89 @@ describe("Story validation", () => {
     expect(new Set(plan.scenes.map((scene) => scene.pattern)).size).toBe(3);
     expect(new Set(plan.scenes.map((scene) => scene.register)).size).toBeGreaterThanOrEqual(2);
     expect(plan.scenes[1].evidenceRefIds).toHaveLength(2);
+  });
+
+  it("accepts grounded one- and two-scene Plans plus an uncited one-scene Boundary Story", () => {
+    const single = makeSingleScenePlan();
+    const unsupportedBoundary = makeSingleScenePlan();
+    unsupportedBoundary.mode = "boundary";
+    unsupportedBoundary.scenes[0].evidenceRefIds = [];
+    const pair = makeTwoScenePlan();
+
+    expect(() => assertValidStoryPlan(single, evidence, single.question)).not.toThrow();
+    expect(() => assertValidStoryPlan(unsupportedBoundary, [], unsupportedBoundary.question)).not.toThrow();
+    expect(() => assertValidStreamPlan(unsupportedBoundary, [], unsupportedBoundary.question)).not.toThrow();
+    expect(() => StoryStreamEventSchema.parse({
+      type: "plan",
+      plan: unsupportedBoundary,
+      evidence: [],
+    })).not.toThrow();
+    expect(() => assertValidStoryPlan(pair, evidence, pair.question)).not.toThrow();
+    expect(single.scenes.map((scene) => [scene.role, scene.cue.phase])).toEqual([
+      ["direct-answer", "intro"],
+    ]);
+    expect(pair.scenes.map((scene) => [scene.role, scene.cue.phase])).toEqual([
+      ["direct-answer", "intro"],
+      ["synthesis", "resolve"],
+    ]);
+  });
+
+  it("rejects role, cue, and Register violations in short Plans", () => {
+    const wrongSingleCue = makeSingleScenePlan();
+    wrongSingleCue.scenes[0].cue.phase = "resolve";
+    expect(() =>
+      assertValidStoryPlan(wrongSingleCue, evidence, wrongSingleCue.question)
+    ).toThrow(/cue phase must be intro/);
+
+    const evidenceEnding = makeTwoScenePlan();
+    evidenceEnding.scenes[1] = {
+      ...makePlan().scenes[1],
+      index: 1,
+    };
+    expect(() =>
+      assertValidStoryPlan(evidenceEnding, evidence, evidenceEnding.question)
+    ).toThrow(/Scene 1 must have role synthesis/);
+
+    const oneRegister = makeTwoScenePlan();
+    oneRegister.scenes[1].register = oneRegister.scenes[0].register;
+    expect(() =>
+      assertValidStoryPlan(oneRegister, evidence, oneRegister.question)
+    ).toThrow(/at least two Registers/);
+
+    const groundedWithoutEvidence = makeSingleScenePlan();
+    groundedWithoutEvidence.scenes[0].evidenceRefIds = [];
+    expect(() =>
+      assertValidStoryPlan(groundedWithoutEvidence, [], groundedWithoutEvidence.question)
+    ).toThrow(/grounded mode requires at least one Evidence Ref/);
+
+    const citedBoundary = makeSingleScenePlan();
+    const boundaryWithUnrelatedVocabulary = makeSingleScenePlan();
+    boundaryWithUnrelatedVocabulary.mode = "boundary";
+    boundaryWithUnrelatedVocabulary.scenes[0].evidenceRefIds = [];
+    expect(() =>
+      assertValidStreamPlan(
+        boundaryWithUnrelatedVocabulary,
+        evidence,
+        boundaryWithUnrelatedVocabulary.question,
+      )
+    ).toThrow(/boundary mode must not include an Evidence vocabulary/);
+
+    citedBoundary.mode = "boundary";
+    expect(() =>
+      assertValidStoryPlan(citedBoundary, evidence, citedBoundary.question)
+    ).toThrow(/boundary mode must not include Evidence Refs/);
+
+    const multiSceneBoundary = makeTwoScenePlan();
+    multiSceneBoundary.mode = "boundary";
+    expect(() =>
+      assertValidStoryPlan(multiSceneBoundary, evidence, multiSceneBoundary.question)
+    ).toThrow(/boundary mode requires exactly one Scene/);
+
+    const missingEvidence = makeTwoScenePlan();
+    missingEvidence.scenes[1].evidenceRefIds = [];
+    expect(() =>
+      assertValidStoryPlan(missingEvidence, evidence, missingEvidence.question)
+    ).toThrow(/grounded mode requires at least one Evidence Ref/);
   });
 
   it("uses one trimmed 280-character Question contract for display and related questions", async () => {

--- a/noah-portfolio/lib/story/public-validation.ts
+++ b/noah-portfolio/lib/story/public-validation.ts
@@ -30,7 +30,7 @@ export function validationError(label: string, error: z.ZodError): Error {
 }
 
 export function parseEvidence(value: unknown): EvidenceRef[] {
-  const result = z.array(EvidenceRefSchema).min(1).max(64).safeParse(value);
+  const result = z.array(EvidenceRefSchema).max(64).safeParse(value);
   if (!result.success) throw validationError("Evidence Refs", result.error);
   return result.data;
 }
@@ -118,13 +118,21 @@ export function assertValidParsedStreamPlan(
   }
 
   const scenes = plan.scenes;
+  if (plan.mode === "boundary") {
+    if (scenes.length !== 1) {
+      throw new Error("Invalid Story Plan: boundary mode requires exactly one Scene");
+    }
+    if (scenes[0].evidenceRefIds.length !== 0) {
+      throw new Error("Invalid Story Plan: boundary mode must not include Evidence Refs");
+    }
+  }
   if (new Set(scenes.map((scene) => scene.id)).size !== scenes.length) {
     throw new Error("Invalid Story Plan: Scene IDs must be unique");
   }
   if (new Set(scenes.map((scene) => scene.pattern)).size !== scenes.length) {
     throw new Error("Invalid Story Plan: Scene Patterns must be unique");
   }
-  if (new Set(scenes.map((scene) => scene.register)).size < 2) {
+  if (scenes.length > 1 && new Set(scenes.map((scene) => scene.register)).size < 2) {
     throw new Error("Invalid Story Plan: at least two Registers are required");
   }
 
@@ -149,11 +157,18 @@ export function assertValidParsedStreamPlan(
         `Invalid Story Plan: ${scene.role} Scene cue phase must be ${EXPECTED_CUE_PHASE_BY_ROLE[scene.role]}`,
       );
     }
+    if (scene.evidenceRefIds.length === 0 && plan.mode !== "boundary") {
+      throw new Error(`Invalid Story Plan: grounded mode requires at least one Evidence Ref for Scene ${index}`);
+    }
     assertGeneratorEligibleAsset(scene.assetId, scene.pattern, "Story Plan");
     assertReferencesExist(scene.evidenceRefIds, evidenceIds, `Story Plan Scene ${index}`);
   }
 
-  if (!scenes.slice(1, -1).some((scene) => scene.evidenceRefIds.length >= 2)) {
+  const middleScenes = scenes.slice(1, -1);
+  if (
+    middleScenes.length > 0
+    && !middleScenes.some((scene) => scene.evidenceRefIds.length >= 2)
+  ) {
     throw new Error("Invalid Story Plan: an evidence-heavy middle Scene must cite at least two Evidence Refs");
   }
   const related = plan.relatedQuestions.map(normalizeQuestion);
@@ -170,9 +185,13 @@ export function assertValidStreamPlan(
 ): asserts plan is StoryPlan {
   const parsed = StoryPlanSchema.safeParse(plan);
   if (!parsed.success) throw validationError("Story Plan", parsed.error);
+  const parsedEvidence = parseEvidence(evidence);
+  if (parsed.data.mode === "boundary" && parsedEvidence.length !== 0) {
+    throw new Error("Invalid Story Plan: boundary mode must not include an Evidence vocabulary");
+  }
   assertValidParsedStreamPlan(
     parsed.data,
-    evidenceIdsFor(parseEvidence(evidence)),
+    evidenceIdsFor(parsedEvidence),
     expectedQuestion,
   );
 }
@@ -216,6 +235,9 @@ export function assertValidPublicStory(story: unknown): asserts story is PublicS
   const parsed = PublicStorySchema.safeParse(story);
   if (!parsed.success) throw validationError("Public Story", parsed.error);
   const { plan, scenes, evidence, displayQuestion } = parsed.data;
+  if (plan.mode === "boundary" && evidence.length !== 0) {
+    throw new Error("Invalid Public Story: boundary mode must not include Evidence");
+  }
   const evidenceIds = evidenceIdsFor(evidence);
   assertValidParsedStreamPlan(plan, evidenceIds, displayQuestion);
   if (scenes.length !== plan.scenes.length) {

--- a/noah-portfolio/lib/story/types.ts
+++ b/noah-portfolio/lib/story/types.ts
@@ -3,7 +3,7 @@ import { isMotionAssetId, type MotionAssetId } from "@/lib/motion-assets/catalog
 import { z } from "zod";
 
 /** Deliberate compatibility boundary for generated Story structure and behavior. */
-export const STORY_CONTRACT_VERSION = "v5" as const;
+export const STORY_CONTRACT_VERSION = "v6" as const;
 
 /** Deliberate compatibility boundary for the authored Corpus used to ground Stories. */
 export const CORPUS_REVISION = "2026-07-14" as const;
@@ -94,7 +94,6 @@ export const SceneCueSchema = z
 
 const EvidenceRefIdsSchema = z
   .array(nonEmptyText(120).regex(SLUG_PATTERN))
-  .min(1)
   .max(12);
 
 export const ProjectSlugSchema = z.enum(PROJECT_SLUGS, {
@@ -158,10 +157,11 @@ export const StorySceneSchema = ScenePlanSchema
 export const StoryPlanSchema = z
   .object({
     question: StoryQuestionSchema,
+    mode: z.enum(["grounded", "boundary"]),
     backdropPreset: z.custom<BackdropPresetName>(isBackdropPresetName, {
       message: "Unknown Backdrop Preset",
     }),
-    scenes: z.array(ScenePlanSchema).min(3).max(5),
+    scenes: z.array(ScenePlanSchema).min(1).max(5),
     relatedQuestions: z.array(StoryQuestionSchema).min(2).max(3),
   })
   .strict();
@@ -178,8 +178,8 @@ export const StoryRecordSchema = z
     storyContractVersion: nonEmptyText(120),
     createdAt: z.string().datetime({ offset: true }),
     plan: StoryPlanSchema,
-    scenes: z.array(StorySceneSchema).min(3).max(5),
-    evidence: z.array(EvidenceRefSchema).min(1).max(64),
+    scenes: z.array(StorySceneSchema).min(1).max(5),
+    evidence: z.array(EvidenceRefSchema).max(64),
   })
   .strict();
 
@@ -216,7 +216,7 @@ export const PublishStoryResponseSchema = z
 export const StoryStreamEventSchema = z.union([
   z.object({ type: z.literal("phase"), phase: z.enum(NON_PUBLISHING_STORY_PHASES) }).strict(),
   StoryPublishingEventSchema,
-  z.object({ type: z.literal("plan"), plan: StoryPlanSchema, evidence: z.array(EvidenceRefSchema).min(1).max(64) }).strict(),
+  z.object({ type: z.literal("plan"), plan: StoryPlanSchema, evidence: z.array(EvidenceRefSchema).max(64) }).strict(),
   z.object({ type: z.literal("scene"), index: z.number().int().min(0).max(4), scene: StorySceneSchema }).strict(),
   PublishStoryResponseSchema,
   z.object({ type: z.literal("error"), message: nonEmptyText(500) }).strict(),

--- a/noah-portfolio/lib/story/types.ts
+++ b/noah-portfolio/lib/story/types.ts
@@ -33,6 +33,7 @@ export const PROJECT_SLUGS = [
   "ask-me-portfolio",
   "llm-comparison",
   "moodify",
+  "story-model-benchmark",
 ] as const;
 export const ELIGIBLE_PATTERNS_BY_ROLE = {
   "direct-answer": ["hero-statement"],

--- a/noah-portfolio/lib/story/validation.ts
+++ b/noah-portfolio/lib/story/validation.ts
@@ -109,6 +109,9 @@ export function assertValidStoryScene(
 /** Validate a schema-parsed private record without re-parsing its Evidence. */
 export function assertValidParsedStoryRecord(record: StoryRecord): void {
   const { plan, scenes, evidence, displayQuestion } = record;
+  if (plan.mode === "boundary" && evidence.length !== 0) {
+    throw new Error("Invalid Story Record: boundary mode must not include Evidence");
+  }
   const validatedEvidence = validatedStoryEvidenceFromParsed(evidence);
   assertKnownStoryPlanProjectSlugs(plan);
   assertValidParsedStreamPlan(plan, validatedEvidence.ids, displayQuestion);

--- a/noah-portfolio/package-lock.json
+++ b/noah-portfolio/package-lock.json
@@ -55,6 +55,7 @@
         "jsdom": "^29.1.1",
         "postcss": "^8",
         "tailwindcss": "^4.3.2",
+        "tsx": "^4.23.1",
         "typescript": "^5",
         "vitest": "^4.1.9"
       }
@@ -395,6 +396,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5981,6 +6424,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -10068,6 +10553,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/noah-portfolio/package.json
+++ b/noah-portfolio/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
+    "eval": "tsx scripts/story-model-eval.ts",
     "e2e": "playwright test"
   },
   "dependencies": {
@@ -59,6 +60,7 @@
     "jsdom": "^29.1.1",
     "postcss": "^8",
     "tailwindcss": "^4.3.2",
+    "tsx": "^4.23.1",
     "typescript": "^5",
     "vitest": "^4.1.9"
   }

--- a/noah-portfolio/public/story-model-benchmark-cover.svg
+++ b/noah-portfolio/public/story-model-benchmark-cover.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-label="Story model benchmark results">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#26232c"/>
+      <stop offset="1" stop-color="#37304a"/>
+    </linearGradient>
+    <linearGradient id="winner" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0" stop-color="#7fe0bd" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#7fe0bd"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#bg)"/>
+  <g fill="none" stroke="#eae6f2" stroke-opacity="0.08">
+    <path d="M56 72H544M56 136H544M56 200H544M56 264H544M56 328H544"/>
+    <path d="M96 56V344M176 56V344M256 56V344M336 56V344M416 56V344M496 56V344"/>
+  </g>
+  <g transform="translate(70 88)">
+    <rect x="0" y="154" width="38" height="78" rx="7" fill="#c9b3ec" fill-opacity="0.55"/>
+    <rect x="56" y="114" width="38" height="118" rx="7" fill="#e88d67" fill-opacity="0.7"/>
+    <rect x="112" y="66" width="38" height="166" rx="7" fill="url(#winner)"/>
+    <rect x="168" y="132" width="38" height="100" rx="7" fill="#c9b3ec" fill-opacity="0.45"/>
+    <rect x="224" y="176" width="38" height="56" rx="7" fill="#e88d67" fill-opacity="0.5"/>
+    <rect x="280" y="188" width="38" height="44" rx="7" fill="#c9b3ec" fill-opacity="0.35"/>
+    <rect x="336" y="202" width="38" height="30" rx="7" fill="#e88d67" fill-opacity="0.38"/>
+    <circle cx="131" cy="48" r="12" fill="#7fe0bd"/>
+    <path d="m126 48 4 4 8-10" stroke="#26232c" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <g fill="#eae6f2" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
+    <text x="70" y="54" font-size="17" fill="#bdb6d0" letter-spacing="2">STORY PIPELINE / 07 MODELS</text>
+    <text x="70" y="358" font-size="27" font-weight="700">Model benchmark</text>
+    <text x="542" y="358" font-size="14" fill="#7fe0bd" text-anchor="end">GLM 5.2</text>
+  </g>
+</svg>

--- a/noah-portfolio/scripts/story-model-eval.ts
+++ b/noah-portfolio/scripts/story-model-eval.ts
@@ -353,6 +353,7 @@ function benchmarkModel(
   metrics: PipelineMetrics,
   existing: BenchmarkModel | undefined,
   pricing: ModelPricing | undefined,
+  runDate: string,
 ): BenchmarkModel {
   return {
     id: metrics.modelId,
@@ -374,6 +375,7 @@ function benchmarkModel(
     ...(pricing ? { pricing } : {}),
     verdict: existing?.verdict ?? "candidate",
     note: existing?.note ?? "",
+    runDate,
   };
 }
 
@@ -395,23 +397,23 @@ export function mergePipelineResults(
           freshPricing
             ? { ...freshPricing, pricedAt: runDate }
             : existingModel?.pricing,
+          runDate,
         ),
       ];
     }),
   );
   const existingIds = new Set(existing?.models.map((model) => model.id));
+  const models = [
+    ...(existing?.models.map((model) => measured.get(model.id) ?? model) ?? []),
+    ...metrics
+      .filter((result) => !existingIds.has(result.modelId))
+      .map((result) => measured.get(result.modelId)!),
+  ];
   return {
     benchmark: existing?.benchmark ?? "story-pipeline",
-    runDate,
-    questionsPerModel: metrics[0]?.stories ?? 0,
     pricingNote: existing?.pricingNote ?? DEFAULT_PRICING_NOTE,
     source: existing?.source ?? "scripts/story-model-eval.ts --pipeline",
-    models: [
-      ...(existing?.models.map((model) => measured.get(model.id) ?? model) ?? []),
-      ...metrics
-        .filter((result) => !existingIds.has(result.modelId))
-        .map((result) => measured.get(result.modelId)!),
-    ],
+    models,
   };
 }
 
@@ -644,6 +646,8 @@ async function main(): Promise<void> {
       "self-test": { type: "boolean" },
     },
   });
+  if (values.out && !values.pipeline) throw new Error("--out requires --pipeline");
+  if (values.out && values.quick) throw new Error("--quick cannot be combined with --out");
   if (values["self-test"]) {
     const bodies = [
       "One two three four.",
@@ -694,8 +698,6 @@ async function main(): Promise<void> {
     ];
     const existingResults: BenchmarkResults = {
       benchmark: "story-pipeline",
-      runDate: "2026-07-17",
-      questionsPerModel: 5,
       pricingNote: "Existing pricing note",
       source: "existing source",
       models: [
@@ -719,6 +721,7 @@ async function main(): Promise<void> {
           },
           verdict: "finalist",
           note: "Keep this note",
+          runDate: "2026-07-17",
         },
       ],
     };
@@ -736,6 +739,23 @@ async function main(): Promise<void> {
     const withoutFreshPricing = mergePipelineResults(
       pipelineMetrics,
       existingResults,
+      {},
+      "2026-07-18",
+    );
+    const partialExistingResults: BenchmarkResults = {
+      ...existingResults,
+      models: [
+        ...existingResults.models,
+        {
+          ...existingResults.models[0]!,
+          id: "vendor/untouched",
+          label: "Untouched",
+        },
+      ],
+    };
+    const partialMerge = mergePipelineResults(
+      [pipelineMetrics[0]!],
+      partialExistingResults,
       {},
       "2026-07-18",
     );
@@ -770,13 +790,17 @@ async function main(): Promise<void> {
     assert.equal(candidate?.planFirstTryValid, 0);
     assert.equal(candidate?.scenesValid, 0);
     assert.equal(candidate?.repetitionMax, 0);
-    assert.equal(merged.questionsPerModel, 2);
-    assert.equal(merged.runDate, "2026-07-18");
+    assert.equal(existingModel?.runDate, "2026-07-18");
+    assert.equal(candidate?.runDate, "2026-07-18");
     assert.deepEqual(existingModel?.pricing, {
       promptUsdPerTok: 0.001,
       completionUsdPerTok: 0.002,
       pricedAt: "2026-07-18",
     });
+    assert.equal(
+      partialMerge.models.find((model) => model.id === "vendor/untouched")?.runDate,
+      "2026-07-17",
+    );
     assert.deepEqual(retainedPricing, {
       promptUsdPerTok: 0.003,
       completionUsdPerTok: 0.004,

--- a/noah-portfolio/scripts/story-model-eval.ts
+++ b/noah-portfolio/scripts/story-model-eval.ts
@@ -1,0 +1,603 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { generateText } from "ai";
+import {
+  buildSceneRepairMessage,
+  buildSceneSystemPrompt,
+  buildSceneUserMessage,
+  buildSystemPrompt,
+  buildUserMessage,
+} from "../lib/llm/prompt";
+import {
+  CORPUS_EVIDENCE_REFS,
+  resolveStoryProjects,
+} from "../lib/story/evidence";
+import type { ScenePlan, StoryPlan } from "../lib/story/types";
+import {
+  assertValidStoryPlan,
+  assertValidStoryPlanWithEvidence,
+  assertValidStorySceneWithEvidence,
+  validateCanonicalStoryEvidence,
+  type ValidatedStoryEvidence,
+} from "../lib/story/validation";
+
+type ModelConfig = {
+  name: string;
+  model: string;
+};
+
+type ChatMessage = { role: "user" | "assistant"; content: string };
+type TaskName = "plan" | "scene";
+type AttemptTotals = {
+  attempts: number;
+  latencyMs: number;
+  promptTokens: number;
+  completionTokens: number;
+};
+
+type Metrics = AttemptTotals & {
+  model: string;
+  task: TaskName;
+  cases: number;
+  jsonParsed: number;
+  firstTryValid: number;
+  finalValid: number;
+  repairRescued: number;
+  fallbackNeeded: number;
+  sampleBody?: string;
+  note?: string;
+  bodies?: string[];
+};
+
+const MODELS: ModelConfig[] = [
+  {
+    name: "deepseek",
+    model: "deepseek/deepseek-v4-flash",
+  },
+];
+
+const QUESTIONS = [
+  "How does Noah turn complex systems into products?",
+  "Which projects best show Noah's technical range?",
+  "What experience does Noah bring to product engineering?",
+  "How does Noah combine design thinking with engineering?",
+  "Which technologies and systems does Noah work with?",
+] as const;
+
+// Copied from the canonical Story fixture so scene quality is compared against one locked Plan.
+const SCENE_PLAN_FIXTURE = {
+  question: "How does Noah turn complex systems into products?",
+  mode: "grounded",
+  backdropPreset: "ditherTide",
+  scenes: [
+    {
+      id: "direct-answer",
+      index: 0,
+      role: "direct-answer",
+      pattern: "hero-statement",
+      register: "editorial",
+      title: "Systems become usable products",
+      claim: "Noah turns complex systems into products by pairing technical depth with a clear product narrative.",
+      assetId: "circuit-mind",
+      evidenceRefIds: ["bio-headline"],
+      cue: { phase: "intro", focus: "center", intensity: "quiet" },
+    },
+    {
+      id: "grounded-evidence",
+      index: 1,
+      role: "evidence",
+      pattern: "evidence-ledger",
+      register: "technical",
+      title: "Evidence from shipped work",
+      claim: "Shipped project evidence connects product decisions to concrete implementation work.",
+      assetId: "print-layers",
+      evidenceRefIds: ["bio-location", "bio-summary"],
+      projectSlugs: ["ask-me-portfolio", "llm-comparison"],
+      cue: { phase: "develop", focus: "left", intensity: "strong" },
+    },
+    {
+      id: "closing-view",
+      index: 2,
+      role: "synthesis",
+      pattern: "closing-synthesis",
+      register: "reflective",
+      title: "Craft meets delivery",
+      claim: "The result is practical systems work shaped around what people need to understand and use.",
+      assetId: "morning-coffee",
+      evidenceRefIds: ["bio-headline", "bio-summary"],
+      projectSlugs: ["moodify"],
+      cue: { phase: "resolve", focus: "right", intensity: "medium" },
+    },
+  ],
+  relatedQuestions: [
+    "Which projects best show Noah's technical range?",
+    "How does Noah balance engineering and design?",
+  ],
+} satisfies StoryPlan;
+
+function stripFences(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced ? fenced[1].trim() : trimmed;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function complete(
+  model: ModelConfig,
+  system: string,
+  messages: ChatMessage[],
+): Promise<{ text: string; promptTokens: number; completionTokens: number }> {
+
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not set");
+  const result = await generateText({
+    model: createOpenRouter({ apiKey })(model.model),
+    system,
+    messages,
+    temperature: 0.2,
+    abortSignal: AbortSignal.timeout(120_000),
+  });
+  return {
+    text: result.text,
+    promptTokens: result.usage.inputTokens ?? 0,
+    completionTokens: result.usage.outputTokens ?? 0,
+  };
+}
+
+async function modelAttempt(
+  model: ModelConfig,
+  system: string,
+  messages: ChatMessage[],
+  metrics: AttemptTotals,
+): Promise<string> {
+  metrics.attempts += 1;
+  const started = performance.now();
+  try {
+    const result = await complete(model, system, messages);
+    metrics.promptTokens += result.promptTokens;
+    metrics.completionTokens += result.completionTokens;
+    return result.text;
+  } finally {
+    metrics.latencyMs += performance.now() - started;
+  }
+}
+
+function parseSceneBody(parsed: unknown): string {
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    Object.keys(parsed).length !== 1 ||
+    !("body" in parsed) ||
+    typeof parsed.body !== "string"
+  ) {
+    throw new Error('Scene composition must contain only a string "body" field.');
+  }
+  return parsed.body;
+}
+
+function fixtureEvidence(): ValidatedStoryEvidence {
+  assertValidStoryPlan(SCENE_PLAN_FIXTURE, CORPUS_EVIDENCE_REFS, SCENE_PLAN_FIXTURE.question);
+  const usedIds = new Set(SCENE_PLAN_FIXTURE.scenes.flatMap((scene) => scene.evidenceRefIds));
+  const evidence = validateCanonicalStoryEvidence(
+    CORPUS_EVIDENCE_REFS.filter((ref) => usedIds.has(ref.id)),
+  );
+  assertValidStoryPlanWithEvidence(SCENE_PLAN_FIXTURE, evidence, SCENE_PLAN_FIXTURE.question);
+  return evidence;
+}
+function evidenceForPlan(plan: StoryPlan, expectedQuestion: string): ValidatedStoryEvidence {
+  const usedIds = new Set(plan.scenes.flatMap((scene) => scene.evidenceRefIds));
+  const evidence = validateCanonicalStoryEvidence(
+    CORPUS_EVIDENCE_REFS.filter((ref) => usedIds.has(ref.id)),
+  );
+  assertValidStoryPlanWithEvidence(plan, evidence, expectedQuestion);
+  return evidence;
+}
+
+function emptyMetrics(model: ModelConfig, task: TaskName, cases: number): Metrics {
+  return {
+    model: `${model.name} (${model.model})`,
+    task,
+    cases,
+    attempts: 0,
+    jsonParsed: 0,
+    firstTryValid: 0,
+    finalValid: 0,
+    repairRescued: 0,
+    fallbackNeeded: 0,
+    latencyMs: 0,
+    promptTokens: 0,
+    completionTokens: 0,
+  };
+}
+
+async function evaluatePlans(model: ModelConfig, questions: readonly string[]): Promise<Metrics> {
+  const metrics = emptyMetrics(model, "plan", questions.length);
+
+  for (const [caseIndex, question] of questions.entries()) {
+    const messages: ChatMessage[] = [{ role: "user", content: buildUserMessage(question) }];
+    let output = "";
+    let lastError = "The model did not return a valid Story Plan.";
+    let passed = false;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        output = await modelAttempt(model, buildSystemPrompt(), messages, metrics);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(stripFences(output));
+          metrics.jsonParsed += 1;
+        } catch (error) {
+          throw error;
+        }
+        assertValidStoryPlan(parsed, CORPUS_EVIDENCE_REFS, question);
+        if (attempt === 0) metrics.firstTryValid += 1;
+        else metrics.repairRescued += 1;
+        metrics.finalValid += 1;
+        passed = true;
+        break;
+      } catch (error) {
+        lastError = errorMessage(error);
+      }
+
+      if (attempt === 0) {
+        messages.push({ role: "assistant", content: output });
+        messages.push({
+          role: "user",
+          content: `The Story Plan was invalid: ${lastError}\nReturn only a corrected complete Plan. Do not invent Evidence Refs, Motion Asset IDs, or project slugs.`,
+        });
+      }
+    }
+
+    if (!passed) {
+      metrics.fallbackNeeded += 1;
+      metrics.note = lastError;
+    }
+  }
+
+  return metrics;
+}
+
+async function evaluateScenes(
+  model: ModelConfig,
+  question: string,
+  storyOutline: readonly Pick<ScenePlan, "index" | "role" | "title" | "claim">[],
+  scenes: readonly ScenePlan[],
+  storyEvidence: ValidatedStoryEvidence,
+): Promise<Metrics & { bodies: string[] }> {
+  const metrics = { ...emptyMetrics(model, "scene", scenes.length), bodies: [] as string[] };
+
+  for (const [caseIndex, lockedPlan] of scenes.entries()) {
+    const lockedEvidence = storyEvidence.refs.filter((ref) => lockedPlan.evidenceRefIds.includes(ref.id));
+    const resolvedProjects = resolveStoryProjects(lockedPlan.projectSlugs);
+    const system = buildSceneSystemPrompt(question, storyOutline, lockedPlan, lockedEvidence);
+    const messages: ChatMessage[] = [{ role: "user", content: buildSceneUserMessage() }];
+    let output = "";
+    let lastError = "The model did not return a valid Scene body.";
+    let passed = false;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        output = await modelAttempt(model, system, messages, metrics);
+        const parsed: unknown = JSON.parse(stripFences(output));
+        metrics.jsonParsed += 1;
+        const body = parseSceneBody(parsed);
+        const scene: unknown = {
+          ...lockedPlan,
+          body,
+          ...(resolvedProjects ? { projects: resolvedProjects } : {}),
+        };
+        assertValidStorySceneWithEvidence(scene, lockedPlan, storyEvidence);
+        if (attempt === 0) metrics.firstTryValid += 1;
+        else metrics.repairRescued += 1;
+        metrics.finalValid += 1;
+        metrics.sampleBody ??= body;
+        metrics.bodies.push(body);
+        passed = true;
+        break;
+      } catch (error) {
+        lastError = errorMessage(error);
+      }
+
+      if (attempt === 0) {
+        messages.push({ role: "assistant", content: output });
+        messages.push({ role: "user", content: buildSceneRepairMessage(output, lastError) });
+      }
+    }
+
+    if (!passed) {
+      metrics.fallbackNeeded += 1;
+      metrics.sampleBody ??= lockedPlan.claim;
+      metrics.note = lastError;
+      metrics.bodies.push(lockedPlan.claim.trim());
+    }
+  }
+
+  return metrics;
+}
+type PipelineMetrics = AttemptTotals & {
+  model: string;
+  stories: number;
+  planFirstTryValid: number;
+  planFinalValid: number;
+  sceneCases: number;
+  scenesValid: number;
+  measuredStories: number;
+  repetitionMaxTotal: number;
+  repetitionMeanTotal: number;
+  bannedPhraseCount: number;
+  storyLatencyMs: number;
+};
+
+// Keep synchronized with the banned filler rule in ../lib/llm/prompt.ts.
+const BANNED_PHRASES = [
+  "technical depth",
+  "clear product story",
+  "passionate",
+  "seamless",
+  "leveraging",
+  "showcase",
+  "aligning",
+  "robust",
+  "cutting-edge",
+  "The bigger picture",
+  "Impact",
+  "Synthesis of Skills",
+  "Why This Stack Matters",
+  "Making Things That Matter",
+  "shows the kind of work I do",
+  "ability to work across",
+  "core part of my identity",
+  "bridging prototyping with production",
+  "Current Role",
+  "Full-Stack Range",
+] as const;
+
+export function repetitionMetrics(sceneBodies: readonly string[]): { max: number; mean: number } {
+  const trigrams = sceneBodies.map((body) => {
+    const words = body.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+    return new Set(words.slice(0, -2).map((_, index) => words.slice(index, index + 3).join(" ")));
+  });
+  const similarities: number[] = [];
+  for (let left = 0; left < trigrams.length; left += 1) {
+    for (let right = left + 1; right < trigrams.length; right += 1) {
+      let intersection = 0;
+      for (const gram of trigrams[left]) {
+        if (trigrams[right].has(gram)) intersection += 1;
+      }
+      const union = trigrams[left].size + trigrams[right].size - intersection;
+      similarities.push(union ? intersection / union : 0);
+    }
+  }
+  return {
+    max: similarities.length ? Math.max(...similarities) : 0,
+    mean: similarities.length
+      ? similarities.reduce((total, similarity) => total + similarity, 0) / similarities.length
+      : 0,
+  };
+}
+
+function bannedPhraseOccurrences(sceneBodies: readonly string[]): number {
+  return sceneBodies.reduce((storyTotal, body) => {
+    const lower = body.toLowerCase();
+    return storyTotal + BANNED_PHRASES.reduce(
+      (bodyTotal, phrase) => bodyTotal + lower.split(phrase.toLowerCase()).length - 1,
+      0,
+    );
+  }, 0);
+}
+
+function emptyPipelineMetrics(model: ModelConfig, stories: number): PipelineMetrics {
+  return {
+    model: `${model.name} (${model.model})`,
+    stories,
+    attempts: 0,
+    latencyMs: 0,
+    promptTokens: 0,
+    completionTokens: 0,
+    planFirstTryValid: 0,
+    planFinalValid: 0,
+    sceneCases: 0,
+    scenesValid: 0,
+    measuredStories: 0,
+    repetitionMaxTotal: 0,
+    repetitionMeanTotal: 0,
+    bannedPhraseCount: 0,
+    storyLatencyMs: 0,
+  };
+}
+
+async function generatePipelinePlan(
+  model: ModelConfig,
+  question: string,
+  metrics: PipelineMetrics,
+): Promise<StoryPlan | undefined> {
+  const messages: ChatMessage[] = [{ role: "user", content: buildUserMessage(question) }];
+  let output = "";
+  let lastError = "The model did not return a valid Story Plan.";
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      output = await modelAttempt(model, buildSystemPrompt(), messages, metrics);
+      const parsed: unknown = JSON.parse(stripFences(output));
+      assertValidStoryPlan(parsed, CORPUS_EVIDENCE_REFS, question);
+      if (attempt === 0) metrics.planFirstTryValid += 1;
+      metrics.planFinalValid += 1;
+      return parsed;
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+
+    if (attempt === 0) {
+      messages.push({ role: "assistant", content: output });
+      messages.push({
+        role: "user",
+        content: `The Story Plan was invalid: ${lastError}\nReturn only a corrected complete Plan. Do not invent Evidence Refs, Motion Asset IDs, or project slugs.`,
+      });
+    }
+  }
+  return undefined;
+}
+
+async function evaluatePipeline(
+  model: ModelConfig,
+  questions: readonly string[],
+): Promise<PipelineMetrics> {
+  const metrics = emptyPipelineMetrics(model, questions.length);
+
+  for (const question of questions) {
+    const storyStarted = performance.now();
+    try {
+      const plan = await generatePipelinePlan(model, question, metrics);
+      if (!plan) continue;
+      const evidence = evidenceForPlan(plan, question);
+      if (plan.mode === "boundary") continue;
+      const storyOutline = plan.scenes.map(({ index, role, title, claim }) => ({
+        index,
+        role,
+        title,
+        claim,
+      }));
+      const sceneMetrics = await evaluateScenes(
+        model,
+        question,
+        storyOutline,
+        plan.scenes,
+        evidence,
+      );
+      metrics.attempts += sceneMetrics.attempts;
+      metrics.latencyMs += sceneMetrics.latencyMs;
+      metrics.promptTokens += sceneMetrics.promptTokens;
+      metrics.completionTokens += sceneMetrics.completionTokens;
+      metrics.sceneCases += sceneMetrics.cases;
+      metrics.scenesValid += sceneMetrics.finalValid;
+      metrics.measuredStories += 1;
+      const repetition = repetitionMetrics(sceneMetrics.bodies);
+      metrics.repetitionMaxTotal += repetition.max;
+      metrics.repetitionMeanTotal += repetition.mean;
+      metrics.bannedPhraseCount += bannedPhraseOccurrences(sceneMetrics.bodies);
+    } finally {
+      metrics.storyLatencyMs += performance.now() - storyStarted;
+    }
+  }
+  return metrics;
+}
+
+function pipelineTable(metrics: PipelineMetrics[]): string {
+  const rows = metrics.map((result) => {
+    const repetitionMax = result.measuredStories
+      ? (result.repetitionMaxTotal / result.measuredStories).toFixed(3)
+      : "—";
+    const repetitionMean = result.measuredStories
+      ? (result.repetitionMeanTotal / result.measuredStories).toFixed(3)
+      : "—";
+    return `| ${result.model} | ${percent(result.planFirstTryValid, result.stories)} | ${percent(result.planFinalValid, result.stories)} | ${percent(result.scenesValid, result.sceneCases)} | ${repetitionMax} | ${repetitionMean} | ${result.bannedPhraseCount} | ${result.stories ? Math.round(result.storyLatencyMs / result.stories) : "—"} | ${result.promptTokens} | ${result.completionTokens} |`;
+  });
+  return [
+    "| Model | Plan first-try valid | Plan final valid | Scenes valid | Repetition max | Repetition mean | Banned phrases | Mean story ms | Prompt tokens | Completion tokens |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ...rows,
+  ].join("\n");
+}
+
+function percent(count: number, total: number): string {
+  return total ? `${((count / total) * 100).toFixed(0)}%` : "—";
+}
+
+function table(metrics: Metrics[]): string {
+  const rows = metrics.map((result) => {
+    const sample = [result.note, result.sampleBody]
+      .filter((value) => value !== undefined)
+      .join(" — ")
+      .replace(/\s+/g, " ")
+      .replaceAll("|", "\\|")
+      .slice(0, 120) || "—";
+    return `| ${result.model} | ${result.task} | ${result.cases} | ${result.attempts} | ${percent(result.jsonParsed, result.attempts)} | ${percent(result.finalValid, result.attempts)} | ${percent(result.firstTryValid, result.cases)} | ${percent(result.finalValid, result.cases)} | ${result.repairRescued} | ${result.fallbackNeeded} | ${result.attempts ? Math.round(result.latencyMs / result.attempts) : "—"} | ${sample} |`;
+  });
+  return [
+    "| Model | Task | Cases | Attempts | JSON parse/attempt | Valid/attempt | First-try valid (cases) | Final valid (cases) | Repair rescued | Fallback needed | Mean ms | Sample / note |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ...rows,
+  ].join("\n");
+}
+
+function selectedModels(args: string[]): ModelConfig[] {
+  const option = args.find((arg) => arg.startsWith("--models="));
+  const separateIndex = args.indexOf("--models");
+  const requested = (option?.slice("--models=".length) ??
+    (separateIndex >= 0 ? args[separateIndex + 1] : undefined))
+    ?.split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (!requested?.length) return MODELS;
+  return requested.map((name) => {
+    const configured = MODELS.find((model) => model.name === name);
+    if (configured) return configured;
+    if (name.includes("/")) return { name, model: name };
+    throw new Error(
+      `Unknown model "${name}". Choose ${MODELS.map((model) => model.name).join(", ")} or pass an OpenRouter slug containing "/".`,
+    );
+  });
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const quick = args.includes("--quick");
+  if (args.includes("--self-test")) {
+    const bodies = [
+      "One two three four.",
+      "One two three five.",
+      "Nothing shared here now.",
+    ];
+    const first = repetitionMetrics(bodies);
+    const second = repetitionMetrics(bodies);
+    const slug = "qwen/qwen3-30b-a3b";
+    const selected = selectedModels(["--models", slug]);
+    if (
+      JSON.stringify(first) !== JSON.stringify(second) ||
+      first.max !== 1 / 3 ||
+      selected[0]?.name !== slug ||
+      selected[0]?.model !== slug
+    ) {
+      throw new Error("repetition metric self-test failed");
+    }
+    console.log(`repetition metric self-test passed: ${JSON.stringify(first)}`);
+    return;
+  }
+  const pipeline = args.includes("--pipeline");
+  const models = selectedModels(args);
+  const questions = quick ? QUESTIONS.slice(0, 1) : QUESTIONS;
+  if (pipeline) {
+    const results: PipelineMetrics[] = [];
+    for (const model of models) results.push(await evaluatePipeline(model, questions));
+    console.log(`\n# Story model pipeline eval${quick ? " (quick)" : ""}\n`);
+    console.log(pipelineTable(results));
+    return;
+  }
+  const evidence = fixtureEvidence();
+  const scenes = quick ? SCENE_PLAN_FIXTURE.scenes.slice(0, 1) : SCENE_PLAN_FIXTURE.scenes;
+  const storyOutline = SCENE_PLAN_FIXTURE.scenes.map(({ index, role, title, claim }) => ({
+    index,
+    role,
+    title,
+    claim,
+  }));
+  const results: Metrics[] = [];
+
+  for (const model of models) {
+    results.push(await evaluatePlans(model, questions));
+    results.push(
+      await evaluateScenes(model, SCENE_PLAN_FIXTURE.question, storyOutline, scenes, evidence),
+    );
+  }
+
+  console.log(`\n# Story model eval${quick ? " (quick)" : ""}\n`);
+  console.log(table(results));
+}
+
+main().catch((error) => {
+  console.error(errorMessage(error));
+  process.exitCode = 1;
+});

--- a/noah-portfolio/scripts/story-model-eval.ts
+++ b/noah-portfolio/scripts/story-model-eval.ts
@@ -1,6 +1,12 @@
+// Refresh benchmark data: npm run eval -- --pipeline --models <slug> --out lib/benchmark/results.json
+
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText } from "ai";
 import {
+  BANNED_PHRASES,
   buildSceneRepairMessage,
   buildSceneSystemPrompt,
   buildSceneUserMessage,
@@ -12,6 +18,7 @@ import {
   resolveStoryProjects,
 } from "../lib/story/evidence";
 import type { ScenePlan, StoryPlan } from "../lib/story/types";
+import type { BenchmarkModel, BenchmarkResults, ModelPricing } from "../lib/benchmark/data";
 import {
   assertValidStoryPlan,
   assertValidStoryPlanWithEvidence,
@@ -216,7 +223,7 @@ function emptyMetrics(model: ModelConfig, task: TaskName, cases: number): Metric
 async function evaluatePlans(model: ModelConfig, questions: readonly string[]): Promise<Metrics> {
   const metrics = emptyMetrics(model, "plan", questions.length);
 
-  for (const [caseIndex, question] of questions.entries()) {
+  for (const question of questions) {
     const messages: ChatMessage[] = [{ role: "user", content: buildUserMessage(question) }];
     let output = "";
     let lastError = "The model did not return a valid Story Plan.";
@@ -225,13 +232,8 @@ async function evaluatePlans(model: ModelConfig, questions: readonly string[]): 
     for (let attempt = 0; attempt < 2; attempt += 1) {
       try {
         output = await modelAttempt(model, buildSystemPrompt(), messages, metrics);
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(stripFences(output));
-          metrics.jsonParsed += 1;
-        } catch (error) {
-          throw error;
-        }
+        const parsed: unknown = JSON.parse(stripFences(output));
+        metrics.jsonParsed += 1;
         assertValidStoryPlan(parsed, CORPUS_EVIDENCE_REFS, question);
         if (attempt === 0) metrics.firstTryValid += 1;
         else metrics.repairRescued += 1;
@@ -269,7 +271,7 @@ async function evaluateScenes(
 ): Promise<Metrics & { bodies: string[] }> {
   const metrics = { ...emptyMetrics(model, "scene", scenes.length), bodies: [] as string[] };
 
-  for (const [caseIndex, lockedPlan] of scenes.entries()) {
+  for (const lockedPlan of scenes) {
     const lockedEvidence = storyEvidence.refs.filter((ref) => lockedPlan.evidenceRefIds.includes(ref.id));
     const resolvedProjects = resolveStoryProjects(lockedPlan.projectSlugs);
     const system = buildSceneSystemPrompt(question, storyOutline, lockedPlan, lockedEvidence);
@@ -319,6 +321,7 @@ async function evaluateScenes(
 }
 type PipelineMetrics = AttemptTotals & {
   model: string;
+  modelId: string;
   stories: number;
   planFirstTryValid: number;
   planFinalValid: number;
@@ -331,29 +334,129 @@ type PipelineMetrics = AttemptTotals & {
   storyLatencyMs: number;
 };
 
-// Keep synchronized with the banned filler rule in ../lib/llm/prompt.ts.
-const BANNED_PHRASES = [
-  "technical depth",
-  "clear product story",
-  "passionate",
-  "seamless",
-  "leveraging",
-  "showcase",
-  "aligning",
-  "robust",
-  "cutting-edge",
-  "The bigger picture",
-  "Impact",
-  "Synthesis of Skills",
-  "Why This Stack Matters",
-  "Making Things That Matter",
-  "shows the kind of work I do",
-  "ability to work across",
-  "core part of my identity",
-  "bridging prototyping with production",
-  "Current Role",
-  "Full-Stack Range",
-] as const;
+
+type OpenRouterPricing = Omit<ModelPricing, "pricedAt">;
+type PricingByModel = Readonly<Partial<Record<string, OpenRouterPricing>>>;
+
+const DEFAULT_PRICING_NOTE =
+  "Costs are estimates: run token totals × one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary.";
+
+function benchmarkLabel(modelId: string): string {
+  return (modelId.split("/").at(-1) ?? modelId)
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function benchmarkModel(
+  metrics: PipelineMetrics,
+  existing: BenchmarkModel | undefined,
+  pricing: ModelPricing | undefined,
+): BenchmarkModel {
+  return {
+    id: metrics.modelId,
+    label: existing?.label ?? benchmarkLabel(metrics.modelId),
+    stories: metrics.stories,
+    planFirstTryValid: metrics.stories ? metrics.planFirstTryValid / metrics.stories : 0,
+    planFinalValid: metrics.stories ? metrics.planFinalValid / metrics.stories : 0,
+    scenesValid: metrics.sceneCases ? metrics.scenesValid / metrics.sceneCases : 0,
+    repetitionMax: metrics.measuredStories
+      ? metrics.repetitionMaxTotal / metrics.measuredStories
+      : 0,
+    repetitionMean: metrics.measuredStories
+      ? metrics.repetitionMeanTotal / metrics.measuredStories
+      : 0,
+    bannedPhrases: metrics.bannedPhraseCount,
+    meanStoryMs: metrics.stories ? Math.round(metrics.storyLatencyMs / metrics.stories) : 0,
+    promptTokens: metrics.promptTokens,
+    completionTokens: metrics.completionTokens,
+    ...(pricing ? { pricing } : {}),
+    verdict: existing?.verdict ?? "candidate",
+    note: existing?.note ?? "",
+  };
+}
+
+export function mergePipelineResults(
+  metrics: readonly PipelineMetrics[],
+  existing: BenchmarkResults | undefined,
+  pricing: PricingByModel,
+  runDate: string,
+): BenchmarkResults {
+  const measured = new Map(
+    metrics.map((result) => {
+      const freshPricing = pricing[result.modelId];
+      const existingModel = existing?.models.find((model) => model.id === result.modelId);
+      return [
+        result.modelId,
+        benchmarkModel(
+          result,
+          existingModel,
+          freshPricing
+            ? { ...freshPricing, pricedAt: runDate }
+            : existingModel?.pricing,
+        ),
+      ];
+    }),
+  );
+  const existingIds = new Set(existing?.models.map((model) => model.id));
+  return {
+    benchmark: existing?.benchmark ?? "story-pipeline",
+    runDate,
+    questionsPerModel: metrics[0]?.stories ?? 0,
+    pricingNote: existing?.pricingNote ?? DEFAULT_PRICING_NOTE,
+    source: existing?.source ?? "scripts/story-model-eval.ts --pipeline",
+    models: [
+      ...(existing?.models.map((model) => measured.get(model.id) ?? model) ?? []),
+      ...metrics
+        .filter((result) => !existingIds.has(result.modelId))
+        .map((result) => measured.get(result.modelId)!),
+    ],
+  };
+}
+
+async function openRouterPricing(modelIds: readonly string[]): Promise<PricingByModel> {
+  try {
+    const response = await fetch("https://openrouter.ai/api/v1/models");
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = (await response.json()) as {
+      data?: Array<{
+        id?: string;
+        pricing?: { prompt?: string; completion?: string };
+      }>;
+    };
+    const pricing: Partial<Record<string, OpenRouterPricing>> = {};
+    for (const modelId of modelIds) {
+      const match = payload.data?.find((model) => model.id === modelId);
+      const promptUsdPerTok = Number(match?.pricing?.prompt);
+      const completionUsdPerTok = Number(match?.pricing?.completion);
+      if (
+        match &&
+        Number.isFinite(promptUsdPerTok) &&
+        Number.isFinite(completionUsdPerTok)
+      ) {
+        pricing[modelId] = { promptUsdPerTok, completionUsdPerTok };
+      } else {
+        console.error(`Warning: Fresh OpenRouter pricing not found for ${modelId}.`);
+      }
+    }
+    return pricing;
+  } catch (error) {
+    console.error(
+      `Warning: OpenRouter pricing fetch failed (${errorMessage(error)}); no fresh pricing for ${modelIds.join(", ")}.`,
+    );
+    return {};
+  }
+}
+
+async function readBenchmarkResults(path: string): Promise<BenchmarkResults | undefined> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as BenchmarkResults;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
 
 export function repetitionMetrics(sceneBodies: readonly string[]): { max: number; mean: number } {
   const trigrams = sceneBodies.map((body) => {
@@ -392,6 +495,7 @@ function bannedPhraseOccurrences(sceneBodies: readonly string[]): number {
 function emptyPipelineMetrics(model: ModelConfig, stories: number): PipelineMetrics {
   return {
     model: `${model.name} (${model.model})`,
+    modelId: model.model,
     stories,
     attempts: 0,
     latencyMs: 0,
@@ -454,16 +558,10 @@ async function evaluatePipeline(
       if (!plan) continue;
       const evidence = evidenceForPlan(plan, question);
       if (plan.mode === "boundary") continue;
-      const storyOutline = plan.scenes.map(({ index, role, title, claim }) => ({
-        index,
-        role,
-        title,
-        claim,
-      }));
       const sceneMetrics = await evaluateScenes(
         model,
         question,
-        storyOutline,
+        plan.scenes,
         plan.scenes,
         evidence,
       );
@@ -523,16 +621,10 @@ function table(metrics: Metrics[]): string {
   ].join("\n");
 }
 
-function selectedModels(args: string[]): ModelConfig[] {
-  const option = args.find((arg) => arg.startsWith("--models="));
-  const separateIndex = args.indexOf("--models");
-  const requested = (option?.slice("--models=".length) ??
-    (separateIndex >= 0 ? args[separateIndex + 1] : undefined))
-    ?.split(",")
-    .map((name) => name.trim())
-    .filter(Boolean);
-  if (!requested?.length) return MODELS;
-  return requested.map((name) => {
+function resolveModels(requested?: string): ModelConfig[] {
+  const names = requested?.split(",").map((name) => name.trim()).filter(Boolean);
+  if (!names?.length) return MODELS;
+  return names.map((name) => {
     const configured = MODELS.find((model) => model.name === name);
     if (configured) return configured;
     if (name.includes("/")) return { name, model: name };
@@ -543,9 +635,16 @@ function selectedModels(args: string[]): ModelConfig[] {
 }
 
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const quick = args.includes("--quick");
-  if (args.includes("--self-test")) {
+  const { values } = parseArgs({
+    options: {
+      models: { type: "string" },
+      out: { type: "string" },
+      quick: { type: "boolean" },
+      pipeline: { type: "boolean" },
+      "self-test": { type: "boolean" },
+    },
+  });
+  if (values["self-test"]) {
     const bodies = [
       "One two three four.",
       "One two three five.",
@@ -554,7 +653,136 @@ async function main(): Promise<void> {
     const first = repetitionMetrics(bodies);
     const second = repetitionMetrics(bodies);
     const slug = "qwen/qwen3-30b-a3b";
-    const selected = selectedModels(["--models", slug]);
+    const selected = resolveModels(slug);
+    const pipelineMetrics: PipelineMetrics[] = [
+      {
+        model: "Existing (vendor/existing)",
+        modelId: "vendor/existing",
+        stories: 2,
+        attempts: 5,
+        latencyMs: 100,
+        promptTokens: 120,
+        completionTokens: 80,
+        planFirstTryValid: 1,
+        planFinalValid: 2,
+        sceneCases: 4,
+        scenesValid: 3,
+        measuredStories: 2,
+        repetitionMaxTotal: 0.4,
+        repetitionMeanTotal: 0.2,
+        bannedPhraseCount: 3,
+        storyLatencyMs: 201,
+      },
+      {
+        model: "New (vendor/new-model)",
+        modelId: "vendor/new-model",
+        stories: 0,
+        attempts: 0,
+        latencyMs: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        planFirstTryValid: 0,
+        planFinalValid: 0,
+        sceneCases: 0,
+        scenesValid: 0,
+        measuredStories: 0,
+        repetitionMaxTotal: 0,
+        repetitionMeanTotal: 0,
+        bannedPhraseCount: 0,
+        storyLatencyMs: 0,
+      },
+    ];
+    const existingResults: BenchmarkResults = {
+      benchmark: "story-pipeline",
+      runDate: "2026-07-17",
+      questionsPerModel: 5,
+      pricingNote: "Existing pricing note",
+      source: "existing source",
+      models: [
+        {
+          id: "vendor/existing",
+          label: "Existing Label",
+          stories: 5,
+          planFirstTryValid: 0,
+          planFinalValid: 0,
+          scenesValid: 0,
+          repetitionMax: 0,
+          repetitionMean: 0,
+          bannedPhrases: 0,
+          meanStoryMs: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          pricing: {
+            promptUsdPerTok: 0.003,
+            completionUsdPerTok: 0.004,
+            pricedAt: "2026-07-17",
+          },
+          verdict: "finalist",
+          note: "Keep this note",
+        },
+      ],
+    };
+    const merged = mergePipelineResults(
+      pipelineMetrics,
+      existingResults,
+      {
+        "vendor/existing": {
+          promptUsdPerTok: 0.001,
+          completionUsdPerTok: 0.002,
+        },
+      },
+      "2026-07-18",
+    );
+    const withoutFreshPricing = mergePipelineResults(
+      pipelineMetrics,
+      existingResults,
+      {},
+      "2026-07-18",
+    );
+    const retainedPricing = withoutFreshPricing.models.find(
+      (model) => model.id === "vendor/existing",
+    )?.pricing;
+    const existingModel = merged.models.find((model) => model.id === "vendor/existing");
+    const candidate = merged.models.find((model) => model.id === "vendor/new-model");
+    assert.deepEqual(
+      {
+        planFirstTryValid: existingModel?.planFirstTryValid,
+        planFinalValid: existingModel?.planFinalValid,
+        scenesValid: existingModel?.scenesValid,
+        repetitionMax: existingModel?.repetitionMax,
+        repetitionMean: existingModel?.repetitionMean,
+        meanStoryMs: existingModel?.meanStoryMs,
+      },
+      {
+        planFirstTryValid: 0.5,
+        planFinalValid: 1,
+        scenesValid: 0.75,
+        repetitionMax: 0.2,
+        repetitionMean: 0.1,
+        meanStoryMs: 101,
+      },
+    );
+    assert.equal(existingModel?.verdict, "finalist");
+    assert.equal(existingModel?.note, "Keep this note");
+    assert.equal(candidate?.verdict, "candidate");
+    assert.equal(candidate?.note, "");
+    assert.equal(candidate?.label, "New Model");
+    assert.equal(candidate?.planFirstTryValid, 0);
+    assert.equal(candidate?.scenesValid, 0);
+    assert.equal(candidate?.repetitionMax, 0);
+    assert.equal(merged.questionsPerModel, 2);
+    assert.equal(merged.runDate, "2026-07-18");
+    assert.deepEqual(existingModel?.pricing, {
+      promptUsdPerTok: 0.001,
+      completionUsdPerTok: 0.002,
+      pricedAt: "2026-07-18",
+    });
+    assert.deepEqual(retainedPricing, {
+      promptUsdPerTok: 0.003,
+      completionUsdPerTok: 0.004,
+      pricedAt: "2026-07-17",
+    });
+    assert.equal(candidate?.pricing, undefined);
     if (
       JSON.stringify(first) !== JSON.stringify(second) ||
       first.max !== 1 / 3 ||
@@ -564,36 +792,38 @@ async function main(): Promise<void> {
       throw new Error("repetition metric self-test failed");
     }
     console.log(`repetition metric self-test passed: ${JSON.stringify(first)}`);
+    console.log("benchmark merge self-test passed");
     return;
   }
-  const pipeline = args.includes("--pipeline");
-  const models = selectedModels(args);
-  const questions = quick ? QUESTIONS.slice(0, 1) : QUESTIONS;
-  if (pipeline) {
+  const models = resolveModels(values.models);
+  const questions = values.quick ? QUESTIONS.slice(0, 1) : QUESTIONS;
+  if (values.pipeline) {
     const results: PipelineMetrics[] = [];
     for (const model of models) results.push(await evaluatePipeline(model, questions));
-    console.log(`\n# Story model pipeline eval${quick ? " (quick)" : ""}\n`);
+    console.log(`\n# Story model pipeline eval${values.quick ? " (quick)" : ""}\n`);
     console.log(pipelineTable(results));
+    if (values.out) {
+      const pricing = await openRouterPricing(results.map((result) => result.modelId));
+      const existing = await readBenchmarkResults(values.out);
+      const runDate = new Date().toISOString().slice(0, 10);
+      const merged = mergePipelineResults(results, existing, pricing, runDate);
+      await writeFile(values.out, `${JSON.stringify(merged, null, 2)}\n`);
+      console.log(`\nWrote benchmark data to ${values.out}`);
+    }
     return;
   }
   const evidence = fixtureEvidence();
-  const scenes = quick ? SCENE_PLAN_FIXTURE.scenes.slice(0, 1) : SCENE_PLAN_FIXTURE.scenes;
-  const storyOutline = SCENE_PLAN_FIXTURE.scenes.map(({ index, role, title, claim }) => ({
-    index,
-    role,
-    title,
-    claim,
-  }));
+  const scenes = values.quick ? SCENE_PLAN_FIXTURE.scenes.slice(0, 1) : SCENE_PLAN_FIXTURE.scenes;
   const results: Metrics[] = [];
 
   for (const model of models) {
     results.push(await evaluatePlans(model, questions));
     results.push(
-      await evaluateScenes(model, SCENE_PLAN_FIXTURE.question, storyOutline, scenes, evidence),
+      await evaluateScenes(model, SCENE_PLAN_FIXTURE.question, SCENE_PLAN_FIXTURE.scenes, scenes, evidence),
     );
   }
 
-  console.log(`\n# Story model eval${quick ? " (quick)" : ""}\n`);
+  console.log(`\n# Story model eval${values.quick ? " (quick)" : ""}\n`);
   console.log(table(results));
 }
 


### PR DESCRIPTION
## What

Three commits:

1. **feat(story): story quality overhaul** — grounded prompts, variable scene counts, `z-ai/glm-5.2` as the default model (selected by the 2026-07-18 blinded model shootout).
2. **refactor(story):** export canonical `BANNED_PHRASES` from `lib/llm/prompt.ts`; drop duplicated scene-outline/evidence mapping.
3. **feat(benchmark):** the shootout, visualized and made repeatable:
   - `/benchmark` page (linked from top nav): efficiency-frontier scatter (log latency × estimated $/Story), plan-validity dumbbell (first-try vs after-repair), quality fingerprint (repetition Jaccard + banned phrases). Hand-rolled SVG + framer-motion, theme-token styled for light/dark, reduced-motion safe, visually-hidden table fallbacks.
   - `lib/benchmark/results.json` + typed `data.ts`: seeded with the real 7-model pipeline run; per-model OpenRouter pricing snapshots with own `pricedAt`; all dollar figures labeled estimates (auto-routing price spread).
   - `scripts/story-model-eval.ts --pipeline --out lib/benchmark/results.json`: merges results by model id, preserves curated verdicts/notes and prior pricing on lookup misses; `npm run eval`; extended `--self-test` (no API key needed).
   - Corpus: `story-model-benchmark` project entry (citable evidence, slug registered in `PROJECT_SLUGS`) + `docs/story-model-benchmark.md` (questions, metric denominators, edge cases, rerun recipe for future models). Automated validation is scoped honestly: schema/evidence-vocabulary checks are automated; semantic entailment is blinded manual review.

## Verification

- `npx tsc --noEmit` clean; `npx vitest run`: 38 files / 291 tests pass
- `npm run eval -- --self-test` passes (merge + repetition metrics)
- `/benchmark` browser-verified: 3 charts × 7 models, light + dark, 1440px + 390px, reduced-motion emulation; nav link routes correctly
