### PR TITLE
Free-tier model fallback: keep Story generation alive when credits run out

### DIFF
--- a/noah-portfolio/.env.local.example
+++ b/noah-portfolio/.env.local.example
@@ -3,6 +3,8 @@ OPENROUTER_API_KEY=
 OPENROUTER_MODEL=z-ai/glm-5.2
 # Optional provider preference; fallbacks remain enabled. Novita was the cheapest GLM-5.2 endpoint at time of writing (fp8, $0.30/$0.93 per M tokens); shootout quality was measured via OpenRouter auto-routing — if you pin a provider, re-verify with scripts/story-model-eval.ts --pipeline since quantization can change quality.
 # OPENROUTER_PROVIDER_ORDER=novita
+# Free-tier fallback chain defaults in code to tencent/hy3:free; set "" to disable. OpenRouter's server-side fallback and an app-level 402 retry are both active. tencent/hy3:free is the only free model usable without opting into prompt-logging at https://openrouter.ai/settings/privacy (verified 2026-07-20).
+OPENROUTER_FALLBACK_MODELS=tencent/hy3:free
 CF_ACCOUNT_ID=
 CF_D1_DATABASE_ID=
 CF_D1_TOKEN=

--- a/noah-portfolio/content/about-me/projects/story-model-benchmark.md
+++ b/noah-portfolio/content/about-me/projects/story-model-benchmark.md
@@ -17,3 +17,5 @@ description: >-
 ---
 
 A production-pipeline benchmark for choosing the portfolio's Story-generation model with validity, grounding, repetition, latency, token, and estimated-cost evidence.
+
+The benchmark also selects the free-tier fallback: `tencent/hy3:free` (60% first-try / 80% final plan validity, 100% scene validity, ~19 s per Story) is wired as the default `OPENROUTER_FALLBACK_MODELS` chain, so Story generation degrades gracefully instead of failing when paid credits run out.

--- a/noah-portfolio/docs/story-model-benchmark.md
+++ b/noah-portfolio/docs/story-model-benchmark.md
@@ -93,3 +93,13 @@ Use `--quick` to run only the first fixed question while checking credentials or
 | `qwen/qwen3.5-35b-a3b` | 0% | 20% | 67% | 0.017 | 0.006 | 0 | 296,394 | 13,405 | 27,592 |
 
 A blinded review ranked the viable finalists **C > A > B**: A was DeepSeek V4 Flash, B was GPT-OSS 120B, and C was GLM-5.2. GLM-5.2 covered the broadest set of projects and had no entailment violations in the reviewed output. It also combined 80% first-try and 100% final plan validity, zero banned phrases, 0.039 maximum repetition, and about 39 seconds per Story. DeepSeek repeated more and took about 68 seconds; GPT-OSS was much faster but used a banned phrase and invented an evidence relationship. GLM-5.2 and DeepSeek were MIT-licensed; GPT-OSS was Apache-2.0. The review selected `z-ai/glm-5.2` as the application default while retaining OpenRouter auto-routing unless an operator deliberately sets a provider order and reruns the benchmark.
+
+## 2026-07-20 free-fallback run
+
+A follow-up run measured `tencent/hy3:free`, the only OpenRouter `:free` model available without opting the account into prompt-logging/training. The goal was an out-of-credits fallback, not a new default.
+
+| Model | Plan first-try valid | Plan final valid | Scenes valid | Repetition max | Repetition mean | Banned phrases | Mean Story ms | Prompt tokens | Completion tokens |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `tencent/hy3:free` | 60% | 80% | 100% | 0.124 | 0.034 | 0 | 18,615 | 54,314 | 5,388 |
+
+One Story in five kept an invalid plan after the repair attempt, so this is a degraded mode relative to GLM-5.2 (80% first-try, 100% final). It is wired as the default fallback chain: `lib/env.ts` defaults `OPENROUTER_FALLBACK_MODELS` to `tencent/hy3:free` (empty string disables), and `lib/llm/openrouter.ts` passes the chain as OpenRouter's server-side `models` fallback plus an application-level retry on insufficient-credit (402) errors. Free endpoints are rate-limited by OpenRouter (1,000 requests/day for accounts with ≥$10 lifetime purchases, otherwise 50/day), which is fine for fallback traffic but not for repeated eval loops.

--- a/noah-portfolio/lib/__tests__/env.test.ts
+++ b/noah-portfolio/lib/__tests__/env.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
   vi.stubEnv("OPENROUTER_API_KEY", "test-key");
   vi.stubEnv("OPENROUTER_MODEL", "");
   vi.stubEnv("OPENROUTER_PROVIDER_ORDER", undefined);
+  vi.stubEnv("OPENROUTER_FALLBACK_MODELS", undefined);
   vi.stubEnv("CF_ACCOUNT_ID", "");
   vi.stubEnv("STORY_CACHE_HMAC_KEY", "");
   vi.stubEnv("STORY_CACHE_HMAC_KEY_ID", "");
@@ -48,6 +49,42 @@ describe("LLM environment", () => {
     "rejects empty provider-order entries in %j",
     (providerOrder) => {
       vi.stubEnv("OPENROUTER_PROVIDER_ORDER", providerOrder);
+      expect(() => getServerEnv()).toThrow(/must not contain empty entries/);
+    },
+  );
+
+  it("defaults fallback models to the free-tier model", () => {
+    expect(getServerEnv().openrouterFallbackModels).toEqual(["tencent/hy3:free"]);
+  });
+
+  it("treats an empty fallback-model list as unset", () => {
+    vi.stubEnv("OPENROUTER_FALLBACK_MODELS", "");
+    expect(getServerEnv().openrouterFallbackModels).toBeUndefined();
+  });
+
+  it("parses CSV fallback models", () => {
+    vi.stubEnv("OPENROUTER_FALLBACK_MODELS", "tencent/hy3:free,openai/gpt-oss-20b:free");
+    expect(getServerEnv().openrouterFallbackModels).toEqual([
+      "tencent/hy3:free",
+      "openai/gpt-oss-20b:free",
+    ]);
+  });
+
+  it("trims fallback-model whitespace", () => {
+    vi.stubEnv(
+      "OPENROUTER_FALLBACK_MODELS",
+      " tencent/hy3:free , openai/gpt-oss-20b:free ",
+    );
+    expect(getServerEnv().openrouterFallbackModels).toEqual([
+      "tencent/hy3:free",
+      "openai/gpt-oss-20b:free",
+    ]);
+  });
+
+  it.each(["tencent/hy3:free,,openai/gpt-oss-20b:free", "tencent/hy3:free,", "   "])(
+    "rejects empty fallback-model entries in %j",
+    (fallbackModels) => {
+      vi.stubEnv("OPENROUTER_FALLBACK_MODELS", fallbackModels);
       expect(() => getServerEnv()).toThrow(/must not contain empty entries/);
     },
   );

--- a/noah-portfolio/lib/benchmark/results.json
+++ b/noah-portfolio/lib/benchmark/results.json
@@ -1,6 +1,6 @@
 {
   "benchmark": "story-pipeline",
-  "pricingNote": "Costs are estimates: run token totals \u00d7 one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary materially (GLM-5.2 endpoints ranged $0.2968/$0.9328 to $1.05/$4.40 per MTok at review time).",
+  "pricingNote": "Costs are estimates: run token totals × one OpenRouter price snapshot per model. The eval used auto-routing, and per-provider endpoint prices vary materially (GLM-5.2 endpoints ranged $0.2968/$0.9328 to $1.05/$4.40 per MTok at review time).",
   "source": "scripts/story-model-eval.ts --pipeline",
   "models": [
     {
@@ -17,8 +17,8 @@
       "promptTokens": 57631,
       "completionTokens": 28190,
       "pricing": {
-        "promptUsdPerTok": 2.94e-07,
-        "completionUsdPerTok": 9.24e-07,
+        "promptUsdPerTok": 2.94e-7,
+        "completionUsdPerTok": 9.24e-7,
         "pricedAt": "2026-07-18"
       },
       "verdict": "default",
@@ -39,8 +39,8 @@
       "promptTokens": 45334,
       "completionTokens": 31247,
       "pricing": {
-        "promptUsdPerTok": 9.8e-08,
-        "completionUsdPerTok": 1.96e-07,
+        "promptUsdPerTok": 9.8e-8,
+        "completionUsdPerTok": 1.96e-7,
         "pricedAt": "2026-07-18"
       },
       "verdict": "finalist",
@@ -61,8 +61,8 @@
       "promptTokens": 64975,
       "completionTokens": 23272,
       "pricing": {
-        "promptUsdPerTok": 3.7e-08,
-        "completionUsdPerTok": 1.7e-07,
+        "promptUsdPerTok": 3.7e-8,
+        "completionUsdPerTok": 1.7e-7,
         "pricedAt": "2026-07-18"
       },
       "verdict": "finalist",
@@ -83,8 +83,8 @@
       "promptTokens": 47026,
       "completionTokens": 55949,
       "pricing": {
-        "promptUsdPerTok": 2.6e-07,
-        "completionUsdPerTok": 2.6e-06,
+        "promptUsdPerTok": 2.6e-7,
+        "completionUsdPerTok": 0.0000026,
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
@@ -105,8 +105,8 @@
       "promptTokens": 71569,
       "completionTokens": 7088,
       "pricing": {
-        "promptUsdPerTok": 1.5e-07,
-        "completionUsdPerTok": 6e-07,
+        "promptUsdPerTok": 1.5e-7,
+        "completionUsdPerTok": 6e-7,
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
@@ -127,12 +127,12 @@
       "promptTokens": 62423,
       "completionTokens": 51287,
       "pricing": {
-        "promptUsdPerTok": 6.05e-08,
-        "completionUsdPerTok": 4e-07,
+        "promptUsdPerTok": 6.05e-8,
+        "completionUsdPerTok": 4e-7,
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
-      "note": "232 s per Story with 20% first-try plan validity \u2014 slow and unreliable.",
+      "note": "232 s per Story with 20% first-try plan validity — slow and unreliable.",
       "runDate": "2026-07-18"
     },
     {
@@ -149,13 +149,35 @@
       "promptTokens": 13405,
       "completionTokens": 27592,
       "pricing": {
-        "promptUsdPerTok": 1.4e-07,
-        "completionUsdPerTok": 1e-06,
+        "promptUsdPerTok": 1.4e-7,
+        "completionUsdPerTok": 0.000001,
         "pricedAt": "2026-07-18"
       },
       "verdict": "eliminated",
       "note": "No plan ever validated first try; only one Story survived repair. 296 s per Story.",
       "runDate": "2026-07-18"
+    },
+    {
+      "id": "tencent/hy3:free",
+      "label": "Hy3 (free)",
+      "stories": 5,
+      "planFirstTryValid": 0.6,
+      "planFinalValid": 0.8,
+      "scenesValid": 1,
+      "repetitionMax": 0.12380952380952381,
+      "repetitionMean": 0.03387126268924271,
+      "bannedPhrases": 0,
+      "meanStoryMs": 18615,
+      "promptTokens": 54314,
+      "completionTokens": 5388,
+      "pricing": {
+        "promptUsdPerTok": 0,
+        "completionUsdPerTok": 0,
+        "pricedAt": "2026-07-20"
+      },
+      "verdict": "candidate",
+      "note": "Zero-cost fallback, not a default contender: the only OpenRouter :free model usable without the prompt-logging opt-in. Wired as the app's default OPENROUTER_FALLBACK_MODELS chain for when paid credits run out.",
+      "runDate": "2026-07-20"
     }
   ]
 }

--- a/noah-portfolio/lib/env.ts
+++ b/noah-portfolio/lib/env.ts
@@ -8,6 +8,7 @@ export interface OpenRouterEnv {
   openrouterApiKey: string;
   openrouterModel: string;
   openrouterProviderOrder: string[] | undefined;
+  openrouterFallbackModels: string[] | undefined;
 }
 
 export interface LangfuseEnv {
@@ -29,10 +30,22 @@ export function getServerEnv(): OpenRouterEnv {
     throw new Error("OPENROUTER_PROVIDER_ORDER must not contain empty entries");
   }
 
+  // Default fallback keeps Story generation alive when paid credits run out;
+  // set OPENROUTER_FALLBACK_MODELS="" to disable fallback routing entirely.
+  const fallbackModelsValue = process.env.OPENROUTER_FALLBACK_MODELS ?? "tencent/hy3:free";
+  const fallbackModels =
+    fallbackModelsValue === ""
+      ? undefined
+      : fallbackModelsValue.split(",").map((model) => model.trim());
+  if (fallbackModels?.some((model) => !model)) {
+    throw new Error("OPENROUTER_FALLBACK_MODELS must not contain empty entries");
+  }
+
   return {
     openrouterApiKey,
     openrouterModel: process.env.OPENROUTER_MODEL || "z-ai/glm-5.2",
     openrouterProviderOrder: providerOrder,
+    openrouterFallbackModels: fallbackModels,
   };
 }
 

--- a/noah-portfolio/lib/llm/__tests__/openrouter.test.ts
+++ b/noah-portfolio/lib/llm/__tests__/openrouter.test.ts
@@ -1,0 +1,73 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "@/lib/llm/openrouter";
+
+vi.mock("@openrouter/ai-sdk-provider", () => ({ createOpenRouter: vi.fn() }));
+
+const createOpenRouterMock = vi.mocked(createOpenRouter);
+const modelFactory = vi.fn();
+const primaryGenerate = vi.fn();
+const primaryStream = vi.fn();
+const fallbackGenerate = vi.fn();
+const fallbackStream = vi.fn();
+const fallbackGenerateResult = { content: [] };
+const fallbackStreamResult = { stream: new ReadableStream() };
+const primaryModel = {
+  specificationVersion: "v3" as const,
+  provider: "openrouter",
+  modelId: "primary",
+  supportedUrls: {},
+  doGenerate: primaryGenerate,
+  doStream: primaryStream,
+};
+const fallbackModel = {
+  specificationVersion: "v3" as const,
+  provider: "openrouter",
+  modelId: "fallback",
+  supportedUrls: {},
+  doGenerate: fallbackGenerate,
+  doStream: fallbackStream,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+  vi.stubEnv("OPENROUTER_MODEL", "");
+  vi.stubEnv("OPENROUTER_PROVIDER_ORDER", undefined);
+  vi.stubEnv("OPENROUTER_FALLBACK_MODELS", undefined);
+
+  const creditError = Object.assign(new Error("insufficient credits"), { statusCode: 402 });
+  primaryGenerate.mockRejectedValue(creditError);
+  primaryStream.mockRejectedValue(creditError);
+  fallbackGenerate.mockResolvedValue(fallbackGenerateResult);
+  fallbackStream.mockResolvedValue(fallbackStreamResult);
+  modelFactory.mockImplementation((modelId) =>
+    modelId === "tencent/hy3:free" ? fallbackModel : primaryModel,
+  );
+  createOpenRouterMock.mockReturnValue(modelFactory as never);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("OpenRouter model", () => {
+  it("retries generate and stream with the free model after a credit error", async () => {
+    const model = getModel();
+
+    await expect(model.doGenerate({} as never)).resolves.toBe(fallbackGenerateResult);
+    await expect(model.doStream({} as never)).resolves.toBe(fallbackStreamResult);
+    expect(modelFactory).toHaveBeenCalledWith("z-ai/glm-5.2", {
+      models: ["tencent/hy3:free"],
+    });
+    expect(modelFactory).toHaveBeenCalledWith("tencent/hy3:free", undefined);
+  });
+
+  it("propagates non-credit errors", async () => {
+    const error = new Error("network unavailable");
+    primaryGenerate.mockRejectedValue(error);
+
+    await expect(getModel().doGenerate({} as never)).rejects.toBe(error);
+    expect(fallbackGenerate).not.toHaveBeenCalled();
+  });
+});

--- a/noah-portfolio/lib/llm/__tests__/openrouter.test.ts
+++ b/noah-portfolio/lib/llm/__tests__/openrouter.test.ts
@@ -70,4 +70,20 @@ describe("OpenRouter model", () => {
     await expect(getModel().doGenerate({} as never)).rejects.toBe(error);
     expect(fallbackGenerate).not.toHaveBeenCalled();
   });
+
+  it("propagates non-402 errors whose message mentions payment", async () => {
+    const error = Object.assign(new Error("upstream 500: payment required page returned"), {
+      statusCode: 500,
+    });
+    primaryGenerate.mockRejectedValue(error);
+
+    await expect(getModel().doGenerate({} as never)).rejects.toBe(error);
+    expect(fallbackGenerate).not.toHaveBeenCalled();
+  });
+
+  it("retries on a credit-error message without a status code", async () => {
+    primaryGenerate.mockRejectedValue(new Error("Insufficient credits"));
+
+    await expect(getModel().doGenerate({} as never)).resolves.toBe(fallbackGenerateResult);
+  });
 });

--- a/noah-portfolio/lib/llm/openrouter.ts
+++ b/noah-portfolio/lib/llm/openrouter.ts
@@ -6,13 +6,15 @@ import {
 import { getServerEnv } from "@/lib/env";
 
 function isCreditError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  // An explicit status code is authoritative: only 402 is a credit error.
+  if ("statusCode" in error && error.statusCode !== undefined) {
+    return error.statusCode === 402;
+  }
   return (
-    typeof error === "object" &&
-    error !== null &&
-    (("statusCode" in error && error.statusCode === 402) ||
-      ("message" in error &&
-        typeof error.message === "string" &&
-        /insufficient credits|payment required/i.test(error.message)))
+    "message" in error &&
+    typeof error.message === "string" &&
+    /insufficient credits|payment required/i.test(error.message)
   );
 }
 

--- a/noah-portfolio/lib/llm/openrouter.ts
+++ b/noah-portfolio/lib/llm/openrouter.ts
@@ -1,16 +1,68 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import {
+  type LanguageModelMiddleware as LanguageModelV3Middleware,
+  wrapLanguageModel,
+} from "ai";
 import { getServerEnv } from "@/lib/env";
+
+function isCreditError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (("statusCode" in error && error.statusCode === 402) ||
+      ("message" in error &&
+        typeof error.message === "string" &&
+        /insufficient credits|payment required/i.test(error.message)))
+  );
+}
 
 /**
  * Build the model for Story generation.
  *
  * Environment is read lazily inside this function, so importing this module
  * never throws when provider credentials are unset.
+ * `models` configures OpenRouter's server-side fallback chain when the primary errors, e.g. insufficient credits.
  */
 export function getModel() {
   const env = getServerEnv();
   const openrouter = createOpenRouter({ apiKey: env.openrouterApiKey });
-  return env.openrouterProviderOrder
-    ? openrouter(env.openrouterModel, { provider: { order: env.openrouterProviderOrder } })
-    : openrouter(env.openrouterModel);
+  const primaryModel =
+    !env.openrouterProviderOrder && !env.openrouterFallbackModels
+      ? openrouter(env.openrouterModel)
+      : openrouter(env.openrouterModel, {
+          ...(env.openrouterProviderOrder && {
+            provider: { order: env.openrouterProviderOrder },
+          }),
+          ...(env.openrouterFallbackModels && { models: env.openrouterFallbackModels }),
+        });
+
+  if (!env.openrouterFallbackModels) return primaryModel;
+
+  const fallbackModels = env.openrouterFallbackModels;
+  const fallbackModel = openrouter(
+    fallbackModels[0],
+    fallbackModels.length > 1 ? { models: fallbackModels.slice(1) } : undefined,
+  );
+  // App-level 402 retry: OpenRouter's server-side `models` fallback is not
+  // documented to cover zero-balance 402.
+  const creditFallbackMiddleware: LanguageModelV3Middleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate, params }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        if (!isCreditError(error)) throw error;
+        return fallbackModel.doGenerate(params);
+      }
+    },
+    wrapStream: async ({ doStream, params }) => {
+      try {
+        return await doStream();
+      } catch (error) {
+        if (!isCreditError(error)) throw error;
+        return fallbackModel.doStream(params);
+      }
+    },
+  };
+  return wrapLanguageModel({ model: primaryModel, middleware: creditFallbackMiddleware });
 }


### PR DESCRIPTION
## What

- New `OPENROUTER_FALLBACK_MODELS` env (CSV of OpenRouter slugs), **defaulting to `tencent/hy3:free`** — the only OpenRouter `:free` model usable without the account-level prompt-logging/training opt-in (verified 2026-07-20). Empty string disables.
- `getModel()` now has two fallback layers:
  1. OpenRouter server-side `models` fallback routing (covers provider errors / rate limits / downtime).
  2. App-level `wrapLanguageModel` middleware retrying the fallback chain once on 402 / insufficient-credits errors, since server-side fallback is not documented to cover zero-balance.
- Benchmark: `tencent/hy3:free` pipeline eval added to `lib/benchmark/results.json` (surfaces on `/benchmark`), `docs/story-model-benchmark.md` (2026-07-20 section), and the corpus entry.

## Eval (5 stories, production pipeline)

| Model | Plan 1st-try | Plan final | Scenes | Rep max | s/Story |
|---|---:|---:|---:|---:|---:|
| z-ai/glm-5.2 (default) | 80% | 100% | 100% | 0.039 | 39 |
| tencent/hy3:free (fallback) | 60% | 80% | 100% | 0.124 | 19 |

Degraded mode, not a new default: 1 in 5 stories kept an invalid plan after repair.

## Verification

- `lib/__tests__/env.test.ts` + new `lib/llm/__tests__/openrouter.test.ts` (mocked 402 → fallback result; non-402 rethrows): 29 tests pass; `tsc --noEmit` clean.
- Corpus/benchmark consumers (`lib/story`, `lib/benchmark`, homeSpec render): 41 tests pass.
- Live smoke through real `getModel()`: unavailable primary → response served by `tencent/hy3:free`.
- Caveat: genuine zero-balance 402 not reproducible without draining the account; that path is covered by the mocked middleware test and is best-effort against live OpenRouter behavior.