### PR TITLE
fix: surface HMAC-key cache failures, drop stale deepseek env template

### DIFF
--- a/noah-portfolio/app/api/generate/route.ts
+++ b/noah-portfolio/app/api/generate/route.ts
@@ -386,13 +386,14 @@ export async function POST(req: NextRequest): Promise<Response> {
         { headers: { ...RESPONSE_HEADERS, "x-cache": "pending" } },
       );
     }
-  } catch {
+  } catch (error) {
     if (req.signal.aborted) {
       return new Response(null, {
         headers: { ...RESPONSE_HEADERS, "x-cache": "miss" },
       });
     }
     // Invalid or unavailable cache entries regenerate through the normal pipeline.
+    console.error("Story cache lookup failed; regenerating without cache:", error);
   }
 
   return new Response(generationStream(question, req.signal), {

--- a/scripts/orca-setup.sh
+++ b/scripts/orca-setup.sh
@@ -67,18 +67,7 @@ elif [ "$ROOT_ENV" != "$ENV_FILE" ] && [ -f "$ROOT_ENV" ]; then
 elif [ -f "$EXAMPLE" ]; then
   if cp "$EXAMPLE" "$ENV_FILE"; then log "Created .env.local from .env.local.example - fill in the secrets."; else warn "Failed to copy the example env."; fi
 else
-  cat > "$ENV_FILE" <<'ENVEOF'
-OPENROUTER_API_KEY=
-OPENROUTER_MODEL=deepseek/deepseek-v4-flash
-CF_ACCOUNT_ID=
-CF_D1_DATABASE_ID=
-CF_D1_TOKEN=
-# Server-only HMAC key used for private Story cache identity. Use a long random value in production.
-STORY_CACHE_HMAC_KEY=
-# Non-secret rotation label. Change it whenever STORY_CACHE_HMAC_KEY changes.
-STORY_CACHE_HMAC_KEY_ID=
-ENVEOF
-  if [ -f "$ENV_FILE" ]; then log "Wrote a template .env.local - fill in the secrets."; else warn "Could not write $ENV_FILE"; fi
+  warn "No .env.local.example found - create $ENV_FILE manually."
 fi
 
 # --- dependencies --------------------------------------------------------------


### PR DESCRIPTION
## Diagnosis

Production showed a flood of `Missing STORY_CACHE_HMAC_KEY` errors and no Cloudflare D1 caching. Root cause was deployment env misconfiguration (now fixed in the dashboard): `STORY_CACHE_HMAC_KEY`/`STORY_CACHE_HMAC_KEY_ID` unset, plus a stale `OPENROUTER_MODEL=deepseek/deepseek-v4-flash` override masking the `z-ai/glm-5.2` code default chosen in the 2026-07 shootout.

Two code issues made this hard to see and easy to reintroduce:

1. **Silent cache-read swallow** — `POST /api/generate` caught cache-lookup errors with a bare `catch`, so a hard config error (missing HMAC key) was indistinguishable from a routine cache miss. The failure only surfaced as a trailing stream error *after* paying for a full LLM generation.
2. **Stale env template** — `scripts/orca-setup.sh` carried an unreachable `.env.local` fallback heredoc still pinning the pre-shootout deepseek model and lacking guidance, drifting from `.env.local.example`.

## Changes

- `noah-portfolio/app/api/generate/route.ts`: log `Story cache lookup failed; regenerating without cache: <error>` in the cache-lookup catch so misconfiguration surfaces at first touch.
- `scripts/orca-setup.sh`: delete the fallback template; scaffold `.env.local` only from `.env.local.example` (which correctly carries glm-5.2 + D1/HMAC vars), warn if the example is missing.

## Verification

- `npx vitest run app/api/__tests__/generate.test.ts lib/__tests__/env.test.ts` — 54/54 pass.
- `bash -n scripts/orca-setup.sh` — clean.